### PR TITLE
minor header enhancements

### DIFF
--- a/docs/components/header.js
+++ b/docs/components/header.js
@@ -7,6 +7,7 @@ template.innerHTML = `
     header {
       background-color: var(--accent);
       grid-column: 1 / -1;
+      min-height: 150px;
     }
 
     header .social {
@@ -47,8 +48,7 @@ template.innerHTML = `
           <img
             src="https://img.shields.io/github/stars/ProjectEvergreen/wcc.svg?style=social&logo=github&label=github"
             alt="WCC GitHub badge"
-            width="174px"
-            height="40px"
+            width="135px"
             class="github-badge"
           />
         </a>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

Noticed the header was flashing on reload and that the GitHub badge was looking a little stretched out now that the repo is public.
<img width="1272" alt="Screen Shot 2022-06-08 at 09 19 41" src="https://user-images.githubusercontent.com/895923/172628030-f9c14635-bdfe-4a68-ba29-15e6921147c6.png">


## Summary of Changes
1. Gave header a min height (maybe we should move all styles globally in a <style> tag?)
1. Adjust badge styles and kept within aspect ratio