### PR TITLE
handling for ESM (`type="module"`) packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ $ npm install wc-compiler --save-dev
 
 ### CommonJS
 
-If you need CommonJS support, a separate pre-bundled (with Rollup) distribution of **WCC** is available at _dist/wcc.dist.js_.  Example:
+If you need CommonJS support, a separate pre-bundled (with Rollup) distribution of **WCC** is available at _dist/wcc.dist.cjs_.  Example:
 ```js
-const { renderToString } = require('wc-compiler/dist/wcc.dist');
+const { renderToString } = require('wc-compiler/dist/wcc.dist.cjs');
 ```
 
 ## Documentation

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "files": [
     "src/",
-    "dist/wcc.dist.js"
+    "dist/wcc.dist.cjs"
   ],
   "publishConfig": {
     "access": "public"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import commonjs from '@rollup/plugin-commonjs';
 export default {
   input: 'src/wcc.js',
   output: {
-    file: 'dist/wcc.dist.js',
+    file: 'dist/wcc.dist.cjs',
     format: 'cjs'
   },
   plugins: [


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#67 

Found this issue when using in https://github.com/ProjectEvergreen/eleventy-plugin-wcc
```shell
% npm run demo

> eleventy-plugin-wcc@0.0.1 demo
> npm run build -- --serve


> eleventy-plugin-wcc@0.0.1 build
> npm run clean && eleventy "--serve"


> eleventy-plugin-wcc@0.0.1 clean
> rimraf ./_site

[11ty] Eleventy CLI Fatal Error: (more in DEBUG output)
[11ty] 1. Error in your Eleventy config file '/Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/.eleventy.js'. (via EleventyConfigError)
[11ty] 2. Must use import to load ES Module: /Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/node_modules/wc-compiler/dist/wcc.dist.js
[11ty] require() of ES modules is not supported.
[11ty] require() of /Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/node_modules/wc-compiler/dist/wcc.dist.js from /Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/src/index.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
[11ty] Instead rename wcc.dist.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/node_modules/wc-compiler/package.json. (via Error)
[11ty]
[11ty] Original error stack trace: Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/node_modules/wc-compiler/dist/wcc.dist.js
[11ty] require() of ES modules is not supported.
[11ty] require() of /Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/node_modules/wc-compiler/dist/wcc.dist.js from /Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/src/index.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
[11ty] Instead rename wcc.dist.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/node_modules/wc-compiler/package.json.
[11ty]
[11ty]     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1085:13)
[11ty]     at Module.load (internal/modules/cjs/loader.js:933:32)
[11ty]     at Function.Module._load (internal/modules/cjs/loader.js:774:14)
[11ty]     at Module.require (internal/modules/cjs/loader.js:957:19)
[11ty]     at require (internal/modules/cjs/helpers.js:88:18)
[11ty]     at Object.<anonymous> (/Users/owenbuckley/Workspace/project-evergreen/repos/eleventy-plugin-wcc/src/index.js:1:28)
[11ty]     at Module._compile (internal/modules/cjs/loader.js:1068:30)
[11ty]     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
[11ty]     at Module.load (internal/modules/cjs/loader.js:933:32)
[11ty]     at Function.Module._load (internal/modules/cjs/loader.js:774:14)
```

## Summary of Changes
1. Specified file extension specifically as _.cjs_
1. Updated _README.md_ and _package.json_ accordingly