### PR TITLE
Gracefully handle undefined custom elements with `console.warn` message

### DIFF
--- a/src/wcc.js
+++ b/src/wcc.js
@@ -24,16 +24,21 @@ async function renderComponentRoots(tree, definitions) {
   for (const node of tree.childNodes) {
     if (node.tagName && node.tagName.indexOf('-') > 0) {
       const { tagName } = node;
-      const { moduleURL } = definitions[tagName];
-      const elementInstance = await initializeCustomElement(moduleURL, tagName, node.attrs, definitions);
-      const elementHtml = elementInstance.shadowRoot
-        ? elementInstance.getInnerHTML({ includeShadowRoots: true })
-        : elementInstance.innerHTML;
-      const elementTree = parseFragment(elementHtml);
 
-      node.childNodes = node.childNodes.length === 0
-        ? elementTree.childNodes
-        : [...elementTree.childNodes, ...node.childNodes];
+      if (definitions[tagName]) {
+        const { moduleURL } = definitions[tagName];
+        const elementInstance = await initializeCustomElement(moduleURL, tagName, node.attrs, definitions);
+        const elementHtml = elementInstance.shadowRoot
+          ? elementInstance.getInnerHTML({ includeShadowRoots: true })
+          : elementInstance.innerHTML;
+        const elementTree = parseFragment(elementHtml);
+
+        node.childNodes = node.childNodes.length === 0
+          ? elementTree.childNodes
+          : [...elementTree.childNodes, ...node.childNodes];
+      } else {
+        console.warn(`WARNING: customElement <${tagName}> is not defined.  You may not have imported it yet.`);
+      }
     }
 
     if (node.childNodes && node.childNodes.length > 0) {

--- a/test/cases/nested-elements/src/pages/index.js
+++ b/test/cases/nested-elements/src/pages/index.js
@@ -8,6 +8,9 @@ template.innerHTML = `
 
   <h1>Home Page</h1>
 
+  <!-- https://github.com/ProjectEvergreen/wcc/issues/25 -->
+  <x-undefined-test></x-undefined-test>
+
   <wcc-footer></wcc-footer>
 `;
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #25

## Summary of Changes
1. If a customElement has not been defined, just show a warning message instead of failing outright

> _WARNING: customElement `<xxx-yyyyy>` is not defined.  You may not have imported it yet._