### PR TITLE
empty component should not break compiler

### DIFF
--- a/src/dom-shim.js
+++ b/src/dom-shim.js
@@ -27,7 +27,7 @@ class Element extends Node {
   constructor() {
     super();
     this.shadowRoot = null;
-    this.innerHTML;
+    this.innerHTML = '';
     this.attributes = {};
   }
 
@@ -106,11 +106,13 @@ class HTMLTemplateElement extends HTMLElement {
 
   // TODO open vs closed shadow root
   set innerHTML(html) {
-    this.content.innerHTML = `
-      <template shadowroot="open">
-        ${html}
-      </template>
-    `;
+    if (this.content) {
+      this.content.innerHTML = `
+        <template shadowroot="open">
+          ${html}
+        </template>
+      `;
+    }
   }
 
   get innerHTML() {

--- a/test/cases/empty/empty.spec.js
+++ b/test/cases/empty/empty.spec.js
@@ -1,0 +1,34 @@
+/*
+ * Use Case
+ * Run wcc against a single custom element using with no internal definitions
+ *
+ * User Result
+ * Should run without any errors from the DOM shim.
+ *
+ * User Workspace
+ * src/
+ *   empty.js
+ */
+
+import chai from 'chai';
+import { renderToString } from '../../../src/wcc.js';
+
+const expect = chai.expect;
+
+describe('Run WCC For ', function() {
+  const LABEL = 'Single Custom Element with an empty class definition';
+  let rawHtml;
+
+  before(async function() {
+    const { html } = await renderToString(new URL('./src/empty.js', import.meta.url));
+
+    rawHtml = html;
+  });
+
+  describe(LABEL, function() {
+    it('should be an empty string', function() {
+      expect(rawHtml).to.equal('');
+    });
+  });
+
+});

--- a/test/cases/empty/src/empty.js
+++ b/test/cases/empty/src/empty.js
@@ -1,0 +1,3 @@
+export default class EmptyComponent extends HTMLElement {
+  
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #4 

## Summary of Changes
1. Handle empty component compilation and test case

For reference, Chrome returns `''` for the custom element when running in the browser, so presuming this is per "the spec".
<img width="1202" alt="Screen Shot 2022-08-04 at 2 01 22 PM" src="https://user-images.githubusercontent.com/895923/183255445-6a8d9042-122e-4250-8e72-ae84597e4db5.png">

> _Just through the way inheritance works I guess but setting innerHTML in the `Element.constructor` triggers the setter, hence the guard to ensure the presence of content for `HTMLTemplateElement`_