### PR TITLE
Chore/dist command broken

### DIFF
--- a/.github/workflows/ci-jsx.yml
+++ b/.github/workflows/ci-jsx.yml
@@ -29,3 +29,6 @@ jobs:
     - name: Build
       run: |
         npm run build
+    - name: Dist
+      run: |
+        npm run dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
     - name: Build
       run: |
         npm run build
+    - name: Dist
+      run: |
+        npm run dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-compiler",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-compiler",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.7.0",
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@mapbox/rehype-prism": "^0.8.0",
         "@rollup/plugin-commonjs": "^22.0.0",
+        "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "c8": "^7.11.2",
         "chai": "^4.3.6",
@@ -217,6 +218,18 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.8"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "13.3.0",
@@ -8377,6 +8390,15 @@
           "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
           "dev": true
         }
+      }
+    },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
       }
     },
     "@rollup/plugin-node-resolve": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@mapbox/rehype-prism": "^0.8.0",
     "@rollup/plugin-commonjs": "^22.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "c8": "^7.11.2",
     "chai": "^4.3.6",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
 
 export default {
   input: 'src/wcc.js',
@@ -8,6 +9,7 @@ export default {
     format: 'cjs'
   },
   plugins: [
+    json(),
     nodeResolve(),
     commonjs()
   ]


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Running `npm run dist` is broken, seems related to #73 
```
% npm run dist

> wc-compiler@0.6.0 dist
> rollup -c rollup.config.js


src/wcc.js → dist/wcc.dist.cjs...
[!] (plugin commonjs--resolver) Error: Unexpected token (Note that you need @rollup/plugin-json to import JSON files)
node_modules/escodegen/package.json (2:10)
1: {
2:     "name": "escodegen",
             ^
3:     "description": "ECMAScript code generator",
4:     "homepage": "http://github.com/estools/escodegen",
Error: Unexpected token (Note that you need @rollup/plugin-json to import JSON files)
    at error (/Users/owenbuckley/Workspace/project-evergreen/repos/wcc/node_modules/rollup/dist/shared/rollup.js:198:30)
    at Module.error (/Users/owenbuckley/Workspace/project-evergreen/repos/wcc/node_modules/rollup/dist/shared/rollup.js:12555:16)
    at Module.tryParse (/Users/owenbuckley/Workspace/project-evergreen/repos/wcc/node_modules/rollup/dist/shared/rollup.js:12932:25)
    at Module.setSource (/Users/owenbuckley/Workspace/project-evergreen/repos/wcc/node_modules/rollup/dist/shared/rollup.js:12837:24)
    at ModuleLoader.addModuleSource (/Users/owenbuckley/Workspace/project-evergreen/repos/wcc/node_modules/rollup/dist/shared/rollup.js:22311:20)
```

## Summary of Changes
1. Verify `npm run dist` during `ci`
1. Resolved Rollup build issue