### PR TITLE
Feature/issue 87 jsx coarse grained observability

### DIFF
--- a/docs/pages/docs.md
+++ b/docs/pages/docs.md
@@ -248,5 +248,5 @@ And so now when the attribute is set on this component, the component will re-re
 
 Some notes / limitations:
 - Please be aware of the above linked discussion which is tracking known bugs / feature requests to all things WCC + JSX.
-- We consider the capability of this observability to be "coarse grained" at this time since WCC just re-runs the entire `render` function, replacing of the `innerHTML` for the host component.  Thought it is still WIP, we are exploring a more fine grained system that will more efficient than blowing away all the HTML, a la in the style of [**lit-html**](https://lit.dev/docs/templates/overview/) or [**Solid**'s Signals](https://www.solidjs.com/tutorial/introduction_signals).
+- We consider the capability of this observability to be "coarse grained" at this time since WCC just re-runs the entire `render` function, replacing of the `innerHTML` for the host component.  Thought it is still WIP, we are exploring a more ["fine grained" approach](https://github.com/ProjectEvergreen/wcc/issues/108) that will more efficient than blowing away all the HTML, a la in the style of [**lit-html**](https://lit.dev/docs/templates/overview/) or [**Solid**'s Signals](https://www.solidjs.com/tutorial/introduction_signals).
 - This automatically _reflects properties used in the `render` function to attributes_, so YMMV.

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -259,4 +259,9 @@ export async function handler() {
 
 ## JSX
 
-A current example of a Todo App can be seen in [this repo](https://github.com/thescientist13/todo-app), which is a fork of [this Greenwood based Todo App which uses LitElement](https://github.com/ProjectEvergreen/todo-app).  It can compile JSX for _**the client or the server**_ using [Greenwood](https://www.greenwoodjs.io/), and can even be used with great testing tools like [**@web/test-runner**](https://modern-web.dev/docs/test-runner/overview/)! 💪
+A couple examples of using WCC + JSX are available for reference and reproduction:
+
+* [Counter](https://github.com/thescientist13/greenwood-counter-jsx)
+* [Todo App](https://github.com/thescientist13/todo-app)
+
+Both of these examples can compile JSX for _**the client or the server**_ using [Greenwood](https://www.greenwoodjs.io/), and can even be used with great testing tools like [**@web/test-runner**](https://modern-web.dev/docs/test-runner/overview/)! 💪

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "node ./build.js",
     "serve": "node ./build.js && http-server ./dist --open",
     "start": "npm run develop",
-    "test": "mocha --exclude \"./test/cases/jsx/**\" --exclude \"./test/cases/custom-extension/**\" \"./test/**/**/*.spec.js\"",
+    "test": "mocha --exclude \"./test/cases/jsx*/**\" --exclude \"./test/cases/custom-extension/**\" \"./test/**/**/*.spec.js\"",
     "test:exp": "c8 node --experimental-loader ./test-exp-loader.js ./node_modules/mocha/bin/mocha \"./test/**/**/*.spec.js\"",
     "test:tdd": "npm run test -- --watch",
     "test:tdd:exp": "npm run test:exp -- --watch",

--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -211,12 +211,17 @@ function findThisReferences(context, statement) {
     // this.name = 'something'; // constructor
     references.push(expression.left.property.name);
   } else if(isRenderFunctionContext && type === 'VariableDeclaration') {
-    // const name = this.name;
-    // TODO const { name } = this;
     statement.declarations.forEach(declaration => {
-      const { init } = declaration;
-      if(init && init.object && init.object.type === 'ThisExpression') {
+      const { init, id } = declaration;
+    
+      if(init.object && init.object.type === 'ThisExpression') {
+        // const { description } = this.todo;
         references.push(init.property.name);
+      } else if(init.type === 'ThisExpression' && id && id.properties) {
+        // const { description } = this.todo;
+        id.properties.forEach((property) => {
+          references.push(property.key.name);
+        })
       }
     })
   }

--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -207,23 +207,23 @@ function findThisReferences(context, statement) {
     && expression.type === 'AssignmentExpression'
     && expression.left.object.type === 'ThisExpression';
 
-  if(isConstructorThisAssignment) {
+  if (isConstructorThisAssignment) {
     // this.name = 'something'; // constructor
     references.push(expression.left.property.name);
-  } else if(isRenderFunctionContext && type === 'VariableDeclaration') {
+  } else if (isRenderFunctionContext && type === 'VariableDeclaration') {
     statement.declarations.forEach(declaration => {
       const { init, id } = declaration;
     
-      if(init.object && init.object.type === 'ThisExpression') {
+      if (init.object && init.object.type === 'ThisExpression') {
         // const { description } = this.todo;
         references.push(init.property.name);
-      } else if(init.type === 'ThisExpression' && id && id.properties) {
+      } else if (init.type === 'ThisExpression' && id && id.properties) {
         // const { description } = this.todo;
         id.properties.forEach((property) => {
           references.push(property.key.name);
-        })
+        });
       }
-    })
+    });
   }
 
   return references;
@@ -242,7 +242,6 @@ export function parseJsx(moduleURL) {
   });
   string = '';
 
-
   walk.simple(tree, {
     ClassDeclaration(node) {
       if (node.superClass.name === 'HTMLElement') {
@@ -256,17 +255,17 @@ export function parseJsx(moduleURL) {
                 observedAttributes.constructor = [
                   ...observedAttributes.constructor,
                   ...findThisReferences('constructor', statement)
-                ]
-              })
+                ];
+              });
             } else if (nodeName === 'render') {
               for (const n2 in n1.value.body.body) {
                 const n = n1.value.body.body[n2];
 
-                if(n.type === 'VariableDeclaration') {
+                if (n.type === 'VariableDeclaration') {
                   observedAttributes.render = [
                     ...observedAttributes.render,
                     ...findThisReferences('render', n)
-                  ]
+                  ];
                 } else if (n.type === 'ReturnStatement' && n.argument.type === 'JSXElement') {
                   const html = parseJsxElement(n.argument, moduleContents);
                   const elementTree = getParse(html)(html);
@@ -295,16 +294,16 @@ export function parseJsx(moduleURL) {
   });
 
   // TODO - signals: use constructor, render, HTML attributes?  some, none, or all?
-  if(observedAttributes.constructor.length > 0 && !hasOwnObservedAttributes) {
+  if (observedAttributes.constructor.length > 0 && !hasOwnObservedAttributes) {
     let insertPoint;
-    for(const line of tree.body) {
+    for (const line of tree.body) {
       // test for class MyComponent vs export default class MyComponent
-      if(line.type === 'ClassDeclaration' || (line.declaration && line.declaration.type) === 'ClassDeclaration' ) {
+      if (line.type === 'ClassDeclaration' || (line.declaration && line.declaration.type) === 'ClassDeclaration') {
         const children = !line.declaration
           ? line.body.body
           : line.declaration.body.body;
-        for(const method of children) {
-          if(method.key.name === 'constructor') {
+        for (const method of children) {
+          if (method.key.name === 'constructor') {
             insertPoint = method.start - 1;
             break;
           }

--- a/test/cases/jsx-coarse-grained/fixtures/attribute-changed-callback.txt
+++ b/test/cases/jsx-coarse-grained/fixtures/attribute-changed-callback.txt
@@ -1,0 +1,13 @@
+attributeChangedCallback(name, oldValue, newValue) {
+  function getValue(value) {
+      return value.charAt(0) === '{' || value.charAt(0) === '[' ? JSON.parse(value) : !isNaN(value) ? parseInt(value, 10) : value === 'true' || value === 'false' ? value === 'true' ? true : false : value;
+  }
+  if (newValue !== oldValue) {
+      switch (name) {
+      case 'count':
+          this.count = getValue(newValue);
+          break;
+      }
+      this.render();
+  }
+}

--- a/test/cases/jsx-coarse-grained/fixtures/get-observed-attributes.txt
+++ b/test/cases/jsx-coarse-grained/fixtures/get-observed-attributes.txt
@@ -1,0 +1,3 @@
+static get observedAttributes() {
+  return['count'];
+}

--- a/test/cases/jsx-coarse-grained/jsx-coarse-grained.spec.js
+++ b/test/cases/jsx-coarse-grained/jsx-coarse-grained.spec.js
@@ -1,0 +1,52 @@
+/*
+ * Use Case
+ * Run wcc against a custom element using JSX render function with inferredObservability enabled
+ *
+ * User Result
+ * Should return the expected JavaScript output.
+ *
+ * User Workspace
+ * src/
+ *   counter.jsx
+ */
+import chai from 'chai';
+import fs from 'fs/promises';
+import { renderToString } from '../../../src/wcc.js';
+
+const expect = chai.expect;
+
+describe('Run WCC For ', function() {
+  const LABEL = 'Single Custom Element using JSX';
+  let fixtureAttributeChangedCallback;
+  let fixtureGetObservedAttributes;
+  let meta;
+
+  before(async function() {
+    const { metadata } = await renderToString(new URL('./src/counter.jsx', import.meta.url));
+
+    meta = metadata;
+
+    fixtureAttributeChangedCallback = await fs.readFile(new URL('./fixtures/attribute-changed-callback.txt', import.meta.url), 'utf-8');
+    fixtureGetObservedAttributes = await fs.readFile(new URL('./fixtures/get-observed-attributes.txt', import.meta.url), 'utf-8');
+  });
+
+  describe(LABEL, function() {
+
+    describe('<Counter> component w/ <Badge> and Inferred Observability', function() {
+
+      it('should infer observability by generating a get observedAttributes method', () => {
+        const actual = meta['wcc-counter-jsx'].source.replace(/ /g, '').replace(/\n/g, '');
+        const expected = fixtureGetObservedAttributes.replace(/ /g, '').replace(/\n/g, '');
+
+        expect(actual).to.contain(expected);
+      });
+
+      it('should infer observability by generating an attributeChangedCallback method', () => {
+        const actual = meta['wcc-counter-jsx'].source.replace(/ /g, '').replace(/\n/g, '');
+        const expected = fixtureAttributeChangedCallback.replace(/ /g, '').replace(/\n/g, '');
+
+        expect(actual).to.contain(expected);
+      });
+    });
+  });
+});

--- a/test/cases/jsx-coarse-grained/src/counter.jsx
+++ b/test/cases/jsx-coarse-grained/src/counter.jsx
@@ -1,0 +1,40 @@
+export const inferredObservability = true;
+
+export default class Counter extends HTMLElement {
+  constructor() {
+    super();
+    this.count = 0;
+  }
+
+  increment() {
+    this.count += 1;
+    this.render();
+  }
+
+  decrement() {
+    this.count -= 1;
+    this.render();
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  render() {
+    const { count } = this;
+
+    return (
+      <div>
+        <wcc-badge count={count}></wcc-badge>
+        <h3 data-test="hello123">Counter JSX</h3>
+        <button id="evt-this" onclick={this.decrement}> -  (function reference)</button>
+        <button id="evt-assignment" onclick={this.count -= 1}> - (inline state update)</button>
+        <span>You have clicked <span class="red" id="expression">{count}</span> times</span>
+        <button onclick={this.count += 1}> + (inline state update)</button>
+        <button onclick={this.increment}> + (function reference)</button>
+      </div>
+    );
+  }
+}
+
+customElements.define('wcc-counter-jsx', Counter);

--- a/test/cases/jsx/jsx.spec.js
+++ b/test/cases/jsx/jsx.spec.js
@@ -10,7 +10,6 @@
  *   badge.jsx
  *   counter.jsx
  */
-
 import chai from 'chai';
 import { JSDOM } from 'jsdom';
 import { renderToString } from '../../../src/wcc.js';
@@ -18,7 +17,7 @@ import { renderToString } from '../../../src/wcc.js';
 const expect = chai.expect;
 
 describe('Run WCC For ', function() {
-  const LABEL = 'Single Custom Element using JSX and Declarative Shadow DOM';
+  const LABEL = 'Single Custom Element using JSX';
   let dom;
   let meta;
 
@@ -31,7 +30,7 @@ describe('Run WCC For ', function() {
 
   describe(LABEL, function() {
 
-    describe('<Counter> component', function() {
+    describe('<Counter> component w/ <Badge>', function() {
       let buttons;
 
       before(async function() {
@@ -56,21 +55,21 @@ describe('Run WCC For ', function() {
           expect(span.getAttribute('class')).to.be.equal('unmet');
           expect(span.textContent).to.be.equal('0');
         });
+      });
 
-        describe('Event Handling', () => {
-          // <button onclick={this.decrement}> - </button>
-          it('should handle a this expression', () => {
-            const element = Array.from(buttons).find(button => button.getAttribute('id') === 'evt-this');
+      describe('Event Handling', () => {
+        // <button onclick={this.decrement}> - </button>
+        it('should handle a this expression', () => {
+          const element = Array.from(buttons).find(button => button.getAttribute('id') === 'evt-this');
 
-            expect(element.getAttribute('onclick')).to.be.equal('this.parentElement.parentElement.decrement()');
-          });
-  
-          // <button onclick={this.count -= 1}> - </button>
-          it('should handle an assignment expression with implicit reactivity using this.render', () => {
-            const element = Array.from(buttons).find(button => button.getAttribute('id') === 'evt-assignment');
+          expect(element.getAttribute('onclick')).to.be.equal('this.parentElement.parentElement.decrement()');
+        });
 
-            expect(element.getAttribute('onclick')).to.be.equal('this.parentElement.parentElement.count-=1; this.parentElement.parentElement.render();');
-          });
+        // <button onclick={this.count -= 1}> - </button>
+        it('should handle an assignment expression with implicit reactivity using this.render', () => {
+          const element = Array.from(buttons).find(button => button.getAttribute('id') === 'evt-assignment');
+
+          expect(element.getAttribute('onclick')).to.be.equal('this.parentElement.parentElement.count-=1; this.parentElement.parentElement.render();');
         });
       });
 

--- a/test/cases/jsx/jsx.spec.js
+++ b/test/cases/jsx/jsx.spec.js
@@ -3,7 +3,7 @@
  * Run wcc against a nested custom elements using JSX render function
  *
  * User Result
- * Should return the expected HTML output.
+ * Should return the expected HTML and JavaScript output.
  *
  * User Workspace
  * src/
@@ -80,6 +80,15 @@ describe('Run WCC For ', function() {
 
           expect(element.textContent).to.be.equal('0');
         });    
+      });
+
+      describe('Inferred Observability', () => {
+        it('should not infer observability by default', () => {
+          const actual = meta['wcc-counter-jsx'].source.replace(/ /g, '').replace(/\n/g, '');
+
+          expect(actual).to.not.contain('staticgetobservedAttributes()');
+          expect(actual).to.not.contain('attributeChangedCallback');
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #87 

## Summary of Changes
1. Scan `render` and `constructor` functions for usages of `this` to generate `observedAttributes` and `attributeChangedCallback`
1. Made it optional through being able to `export const inferredObservability = {boolean}`

For example, this
```jsx
export default class Greeting extends HTMLElement {
  constructor() {
    this.name = '';
  }
  
  render() {
   const { name = 'World' } = this;
 
   return (
     <h1>Hello ${name}!</h1>  
  }
}

customElements.define('my-greeting', Greeting);
```

Would produce this
```js
export default class Greeting extends HTMLElement {
  static get observedAttributes() {
    return ['name'];
  }

  constructor() {
    this.name = '';
  }
  
  render() {
   const { name = 'World' } = this;
 
   this.innerHTML = `<h1>Hello ${name}!</h1>`;
  }
}

customElements.define('my-greeting', Greeting);
```

Use it as
```html
<my-greeting name="WCC"></my-greeting>
```

Very simple implementation right now mostly as a nice way to do basic text updates / substations, as can be seen in https://github.com/thescientist13/greenwood-counter-jsx/pull/3

> A more complex approach aiming for more fine grained reactivity, like for lists, would be conducted in a second PR and can be followed along with here https://github.com/thescientist13/todo-app/pull/3

## TODOs
1. [x] Tests
1. [x] Try and get an example of `attributeChangedCallback` with fine grained observability
1. [x] Custom `export` to opt-in / out
1. [x] Refine observability detection algorithm (or track as known issues with concrete examples) for "derived" `this` state - all being tracked in https://github.com/ProjectEvergreen/wcc/issues/88
1. [x] Documentation
    - Add more examples / links to examples
    - Add caveats
    - Optionality (`inferObservability`)
    - mapping props to attrs
1. [x] Clean up console logs / commented out code

## Questions / Observations (follow up issues / discussions)
1. [x] Currently this assumes attributes map to properties.  Need to distinguish the two?  Or just document that we "auto" reflect by default? - documented as such for now
1. [ ] Do we need to get hints / signals of all members in `render` function up front _before_ we parse and / or add instruction sets? - yes, I think we do this now
1. [x] Would be nice if there was a way to "stringify" the function code for better syntax highlighting - will track in our backlog
1. [x] Do we need to match in both `render` _and_ `constructor`?  Or just infer from `render()` only? - Will just use `render` function for now
1. [x] Check if `observedAttributes` or `attributeChangedCallback` exists, and merge?  Or defer to what already exists?  Explicit Opt-in / out?
1. [x] Might be nice to have E2E tests for testing interactivity of generated code in a browser - will track in our backlog