### PR TITLE
check for literals vs template literal for tag name quotes in `customElements.define` call

### DIFF
--- a/src/wcc.js
+++ b/src/wcc.js
@@ -85,7 +85,9 @@ function registerDependencies(moduleURL, definitions, depth = 0) {
     ExpressionStatement(node) {
       if (isCustomElementDefinitionNode(node)) {
         const { arguments: args } = node.expression;
-        const tagName = args[0].value;
+        const tagName = args[0].type === 'Literal'
+          ? args[0].value // single and double quotes
+          : args[0].quasis[0].value.raw; // template literal
         const tree = parseJsx(moduleURL);
         const isEntry = nextDepth - 1 === 1;
 

--- a/test/cases/nested-elements/src/components/footer.js
+++ b/test/cases/nested-elements/src/components/footer.js
@@ -19,4 +19,4 @@ class Footer extends HTMLElement {
 
 export default Footer;
 
-customElements.define('wcc-footer', Footer);
+customElements.define(`wcc-footer`, Footer); // eslint-disable-line quotes


### PR DESCRIPTION
…lements.define calls

<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #97 

## Summary of Changes
1. Check for `Literal` vs `TemplateLiteral` when serializing custom elements tags
1. Add test case