### PR TITLE
remove `path` and `url` node dependencies from main entry points

### DIFF
--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -6,10 +6,8 @@ import escodegen from 'escodegen';
 import fs from 'fs';
 import jsx from 'acorn-jsx';
 import { parse, parseFragment, serialize } from 'parse5';
-import path from 'path';
-import { URL, pathToFileURL } from 'url';
 
-const baseURL = pathToFileURL(`${process.cwd()}/`).href;
+const baseURL = new URL(`file://${process.cwd()}/`);
 const jsxRegex = /\.(jsx)$/;
 
 // TODO same hack as definitions
@@ -25,7 +23,7 @@ function getParse(html) {
 }
 
 export function getParser(moduleURL) {
-  const isJSX = path.extname(moduleURL.pathname) === '.jsx';
+  const isJSX = moduleURL.pathname.split('.').pop() === 'jsx';
 
   if (!isJSX) {
     return;

--- a/src/wcc.js
+++ b/src/wcc.js
@@ -8,7 +8,6 @@ import escodegen from 'escodegen';
 import { getParser, parseJsx } from './jsx-loader.js';
 import { parse, parseFragment, serialize } from 'parse5';
 import fs from 'fs';
-import path from 'path';
 
 function getParse(html) {
   return html.indexOf('<html>') >= 0 || html.indexOf('<body>') >= 0 || html.indexOf('<head>') >= 0
@@ -74,9 +73,10 @@ function registerDependencies(moduleURL, definitions, depth = 0) {
     ImportDeclaration(node) {
       const specifier = node.source.value;
       const isBareSpecifier = specifier.indexOf('.') !== 0 && specifier.indexOf('/') !== 0;
+      const extension = specifier.split('.').pop();
 
       // TODO would like to decouple .jsx from the core, ideally
-      if (!isBareSpecifier && ['.js', '.jsx'].includes(path.extname(specifier))) {
+      if (!isBareSpecifier && ['js', 'jsx'].includes(extension)) {
         const dependencyModuleURL = new URL(node.source.value, moduleURL);
 
         registerDependencies(dependencyModuleURL, definitions, nextDepth);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #36 

## Summary of Changes
1. Remove dependencies on Node specific `path` and `url` dependencies

## TODO
1. [x] Clean up _jsx-loader.js_

----

Unfortunately it seems like `fs` might be here with us a bit per https://github.com/ProjectEvergreen/greenwood/issues/953#issuecomment-1345438259
