### PR TITLE
use underlying JSX loader in testing loader

### DIFF
--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -265,7 +265,8 @@ export async function load(url, context, defaultLoad) {
 
     return {
       format: 'module',
-      source: escodegen.generate(jsFromJsx)
+      source: escodegen.generate(jsFromJsx),
+      shortCircuit: true
     };
   }
 

--- a/test-exp-loader.js
+++ b/test-exp-loader.js
@@ -1,9 +1,8 @@
 // https://jestjs.io/docs/ecmascript-modules
 // https://github.com/nodejs/node/discussions/41711
-import escodegen from 'escodegen';
 import fs from 'fs';
 import path from 'path';
-import { parseJsx } from './src/jsx-loader.js';
+import { load as experimentalLoad } from './src/jsx-loader.js';
 
 export async function load(url, context, defaultLoad) {
   const ext = path.extname(url);
@@ -11,13 +10,7 @@ export async function load(url, context, defaultLoad) {
   if (ext === '') {
     return loadBin(url, context, defaultLoad);
   } else if (ext === '.jsx') {
-    const jsFromJsx = parseJsx(new URL(url));
-
-    return {
-      format: 'module',
-      source: escodegen.generate(jsFromJsx),
-      shortCircuit: true
-    };
+    return experimentalLoad(url, context, defaultLoad);
   } else if (ext === '.css') {
     return {
       format: 'module',


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Realized tests should really be using the actual loader, not a mock.  Mean setting `shortCircuit` on the custom loader