### PR TITLE
add no wrapping entry tag option for renderToString

### DIFF
--- a/docs/pages/docs.md
+++ b/docs/pages/docs.md
@@ -52,6 +52,7 @@ export default Home;
 > _**Note**: **WCC** will wrap or not wrap your _entry point's HTML_ in a custom element tag if you do or do not, respectively, include a `customElements.define` in your entry point.  **WCC** will use the tag name you define as the custom element tag name in the generated HTML.
 >
 > You can opt-out of this by passing `false` as the second parameter to `renderToString`.
+> <!-- eslint-disable no-unused-vars -->
 > ```js
 > const { html } = await renderToString(new URL('...'), false);
 > ```

--- a/docs/pages/docs.md
+++ b/docs/pages/docs.md
@@ -49,7 +49,7 @@ class Home extends HTMLElement {
 export default Home;
 ```
 
-> _**Note**: **WCC** will wrap or not wrap your _entry point's HTML_ in a custom element tag if you do or do not, respectively, include a `customElements.define` in your entry point.  **WCC** will use the tag name you define as the custom element tag name in the generated HTML.
+> _**Note**: **WCC** will wrap or not wrap your _entry point's HTML_ in a custom element tag if you do or do not, respectively, include a `customElements.define` in your entry point.  **WCC** will use the tag name you define as the custom element tag name in the generated HTML._
 >
 > You can opt-out of this by passing `false` as the second parameter to `renderToString`.
 > <!-- eslint-disable no-unused-vars -->

--- a/docs/pages/docs.md
+++ b/docs/pages/docs.md
@@ -49,7 +49,12 @@ class Home extends HTMLElement {
 export default Home;
 ```
 
-> _**Note**: **WCC** will wrap or not wrap your _entry point's HTML_ in a custom element tag if you do or do not, respectively, include a `customElements.define` in your entry point.  **WCC** will use the tag name you define as the custom element tag name in the generated HTML._
+> _**Note**: **WCC** will wrap or not wrap your _entry point's HTML_ in a custom element tag if you do or do not, respectively, include a `customElements.define` in your entry point.  **WCC** will use the tag name you define as the custom element tag name in the generated HTML.
+>
+> You can opt-out of this by passing `false` as the second parameter to `renderToString`.
+> ```js
+> const { html } = await renderToString(new URL('...'), false);
+> ```
 
 ### renderFromHTML
 

--- a/src/wcc.js
+++ b/src/wcc.js
@@ -160,9 +160,9 @@ async function initializeCustomElement(elementURL, tagName, attrs = [], definiti
   }
 }
 
-async function renderToString(elementURL) {
+async function renderToString(elementURL, wrappingEntryTag = true) {
   const definitions = [];
-  const elementTagName = await getTagName(elementURL);
+  const elementTagName = wrappingEntryTag && await getTagName(elementURL);
   const isEntry = !!elementTagName;
   const elementInstance = await initializeCustomElement(elementURL, undefined, undefined, definitions, isEntry);
 
@@ -171,7 +171,7 @@ async function renderToString(elementURL) {
     : elementInstance.innerHTML;
   const elementTree = getParse(elementHtml)(elementHtml);
   const finalTree = await renderComponentRoots(elementTree, definitions);
-  const html = elementTagName ? `
+  const html = wrappingEntryTag && elementTagName ? `
       <${elementTagName}>
         ${serialize(finalTree)}
       </${elementTagName}>

--- a/test/cases/no-wrapping-entry-tag/no-wrapping-entry-tag.spec.js
+++ b/test/cases/no-wrapping-entry-tag/no-wrapping-entry-tag.spec.js
@@ -1,0 +1,37 @@
+/*
+ * Use Case
+ * Run wcc against bundled custom elements with no wrapping enabled.
+ *
+ * User Result
+ * Should return the expected HTML with no top level wrapping tag.
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     no-wrap.js
+ */
+
+import chai from 'chai';
+import { JSDOM } from 'jsdom';
+import { renderToString } from '../../../src/wcc.js';
+
+const expect = chai.expect;
+
+describe('Run WCC For ', function() {
+  const LABEL = 'Bundled Components w/ No Wrapping Entry TAag';
+  let dom;
+
+  before(async function() {
+    const { html } = await renderToString(new URL('./src/no-wrap.js', import.meta.url), false);
+
+    dom = new JSDOM(html);
+  });
+
+  describe(LABEL, function() {
+    describe('no top level wrapping by <wcc-navigation>', function() {
+      it('should have a <footer> tag within the <template> shadowroot', function() {
+        expect(dom.window.document.querySelectorAll('wcc-navigation').length).to.equal(0);
+      });
+    });
+  });
+});

--- a/test/cases/no-wrapping-entry-tag/src/no-wrap.js
+++ b/test/cases/no-wrapping-entry-tag/src/no-wrap.js
@@ -1,0 +1,27 @@
+class Navigation extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <nav>
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="/about">About</a></li>
+          <li><a href="/artists">Artists</a></li>
+        <ul>
+      </nav>
+    `;
+  }
+}
+
+customElements.define('wcc-navigation', Navigation);
+
+class Header extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <header class="header">>
+        <h4>My Personal Blog</h4>
+      </header>
+    `;
+  }
+}
+
+export default Header;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #114 

## Summary of Changes
1. Add support for a an option to enable / disable the presence of a wrapping tag for entry files to `renderToString`

## TODO
1. [x] [how to best handle `metadata` and entry point flag](https://github.com/ProjectEvergreen/wcc/issues/114#issuecomment-1480467315) - https://github.com/ProjectEvergreen/wcc/issues/117
1. [x] Documentation