### PR TITLE
eslint all documentation examples

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 2021,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: {
       jsx: true
@@ -10,6 +10,10 @@ module.exports = {
     browser: false,
     node: true
   },
+  plugins: [
+    'no-only-tests'
+  ],
+  extends: 'plugin:markdown/recommended',
   rules: {
     'comma-dangle': [2, 'never'],
     'no-cond-assign': 2,

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -17,3 +17,4 @@ ignore:
   - .git
   - coverage
   - node_modules
+  - dist

--- a/docs/pages/docs.md
+++ b/docs/pages/docs.md
@@ -8,6 +8,7 @@
 
 This function takes a `URL` "entry point" to a JavaScript file that defines a custom element, and returns the static HTML output of its rendered contents.
 
+<!-- eslint-disable no-unused-vars -->
 ```js
 const { html } = await renderToString(new URL('./src/index.js', import.meta.url));
 ```
@@ -54,6 +55,7 @@ export default Home;
 
 This function takes a string of HTML and an array of any top-level custom elements used in the HTML, and returns the static HTML output of the rendered content.
 
+<!-- eslint-disable no-unused-vars -->
 ```js
 const { html } = await renderFromHTML(`
   <html>
@@ -105,7 +107,7 @@ console.log({ metadata });
  *     'wcc-navigation': { instanceName: 'Navigation', moduleURL: [URL],  isEntry: false }
  *   ]
  * }
- *
+ */
 ```
 
 ## Progressive Hydration
@@ -125,7 +127,8 @@ This will be reflected in the returned `metadata` array from `renderToString`.
  *     'wcc-navigation': { instanceName: 'Navigation', moduleURL: [URL] }
  *   ]
  * }
- *
+ * 
+ */
 ```
 
 The benefit is that this hint can be used to defer loading of these scripts by using an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) (for example), instead of eagerly loading it on page load using a `<script>` tag.
@@ -208,7 +211,7 @@ There are of couple things you will need to do to use WCC with JSX:
 1. NodeJS version needs to be >= `16.x`
 1. You will need to use the _.jsx_ extension
 1. Requires the `--experimental-loaders` flag when invoking NodeJS
-    ```js
+    ```shell
     $ node --experimental-loader ./node_modules/wc-compiler/src/jsx-loader.js server.js
     ```
 

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -29,8 +29,6 @@ export default class ArtistsPage extends HTMLElement {
       this.shadowRoot.innerHTML = html;
     }
   }
-
-  ...
 }
 ```
 
@@ -186,8 +184,8 @@ export async function handler() {
   `);
   const lazyJs = [];
 
-  for (const asset in assets) {
-    const a = assets[asset];
+  for (const asset in metadata) {
+    const a = metadata[asset];
 
     a.tagName = asset;
 
@@ -252,7 +250,7 @@ export async function handler() {
           ${html}
         </body>
       </html>
-    `;
+    `
   };
 }
 ```

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -61,6 +61,7 @@ $ npm install wc-compiler --save-dev
     ```
 
 1. Using NodeJS, create a file that imports `renderToString` and provide it the path to your web component
+<!-- eslint-disable no-unused-vars -->
     ```js
     import { renderToString } from 'wc-compiler';
 

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -60,8 +60,7 @@ $ npm install wc-compiler --save-dev
     customElements.define('wcc-footer', Footer);
     ```
 
-1. Using NodeJS, create a file that imports `renderToString` and provide it the path to your web component
-<!-- eslint-disable no-unused-vars -->
+1. Using NodeJS, create a file that imports `renderToString` and provide it the path to your web component <!-- eslint-disable no-unused-vars -->
     ```js
     import { renderToString } from 'wc-compiler';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "chai": "^4.3.6",
         "concurrently": "^7.1.0",
         "eslint": "^8.14.0",
+        "eslint-plugin-markdown": "^3.0.0",
+        "eslint-plugin-no-only-tests": "^2.6.0",
         "http-server": "^14.1.0",
         "jsdom": "^19.0.0",
         "mocha": "^9.2.2",
@@ -1855,6 +1857,90 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-markdown": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-markdown/-/eslint-plugin-markdown-3.0.0.tgz",
+      "integrity": "sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^0.8.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-markdown/node_modules/mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/eslint-plugin-markdown/node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/eslint-plugin-markdown/node_modules/micromark": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-markdown/node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -9582,6 +9668,61 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-markdown": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-markdown/-/eslint-plugin-markdown-3.0.0.tgz",
+      "integrity": "sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==",
+      "dev": true,
+      "requires": {
+        "mdast-util-from-markdown": "^0.8.5"
+      },
+      "dependencies": {
+        "mdast-util-from-markdown": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+          "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+          "dev": true,
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "mdast-util-to-string": "^2.0.0",
+            "micromark": "~2.11.0",
+            "parse-entities": "^2.0.0",
+            "unist-util-stringify-position": "^2.0.0"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+          "dev": true
+        },
+        "micromark": {
+          "version": "2.11.4",
+          "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+          "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.0.0",
+            "parse-entities": "^2.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.2"
+          }
+        }
+      }
+    },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "clean": "rimraf ./dist",
-    "lint": "ls-lint && eslint \"*.*js\" \"./src/**/**/*.js*\" \"./test/**/**/*.js*\"",
+    "lint": "ls-lint && eslint \"*.*js\" \"./src/**/**/*.js*\" \"./docs/**/*.md\" \"./test/**/**/*.js*\"",
     "develop": "concurrently \"nodemon --watch src --watch docs -e js,md,css,html,jsx ./build.js\" \"http-server ./dist --open\"",
     "build": "node ./build.js",
     "serve": "node ./build.js && http-server ./dist --open",
@@ -56,6 +56,8 @@
     "chai": "^4.3.6",
     "concurrently": "^7.1.0",
     "eslint": "^8.14.0",
+    "eslint-plugin-markdown": "^3.0.0",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "http-server": "^14.1.0",
     "jsdom": "^19.0.0",
     "mocha": "^9.2.2",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Apply eslint to all documentation examples
1. Also add plugin `describe.only` specs