### PR TITLE
enhancement/issue 124 refactor handling and logging for entry points and dependencies with no custom element `export`

### DIFF
--- a/test/cases/no-export/no-export.spec.js
+++ b/test/cases/no-export/no-export.spec.js
@@ -18,16 +18,22 @@ const expect = chai.expect;
 describe('Run WCC For ', function() {
   const LABEL = 'Single Custom Element with no default export';
   let rawHtml;
+  let meta;
 
   before(async function() {
-    const { html } = await renderToString(new URL('./src/no-export.js', import.meta.url));
+    const { html, metadata } = await renderToString(new URL('./src/no-export.js', import.meta.url));
 
     rawHtml = html;
+    meta = metadata;
   });
 
   describe(LABEL, function() {
     it('should not throw an error', function() {
-      expect(rawHtml).to.equal('');
+      expect(rawHtml).to.equal(undefined);
+    });
+
+    it('should not have any definition', function() {
+      expect(meta.length).to.equal(0);
     });
   });
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #124 

## Summary of Changes
1. Don't log out when checking for custom elements in `initializeCustomElement `
1. Add logging if `renderToString` entry point is not a custom element
1. Updated no export spec