### PR TITLE
enhancement/use `getRootNode` for `this` references in JSX DSD

### DIFF
--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -38,6 +38,7 @@ export function getParser(moduleURL) {
   };
 }
 
+// replace all instances of __this__ marker with relative reference to the custom element parent node
 function applyDomDepthSubstitutions(tree, currentDepth = 1, hasShadowRoot = false) {
   try {
     for (const node of tree.childNodes) {
@@ -50,9 +51,9 @@ function applyDomDepthSubstitutions(tree, currentDepth = 1, hasShadowRoot = fals
           const { value } = attrs[attr];
 
           if (value.indexOf('__this__.') >= 0) {
-            const root = hasShadowRoot ? 'parentNode.host' : 'parentElement';
-
-            node.attrs[attr].value = value.replace(/__this__/g, `this${'.parentElement'.repeat(currentDepth - 1)}.${root}`);
+            const root = hasShadowRoot ? '.getRootNode().host' : `${'.parentElement'.repeat(currentDepth)}`;
+          
+            node.attrs[attr].value = value.replace(/__this__/g, `this${root}`);
           }
         }
       }

--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -52,7 +52,7 @@ function applyDomDepthSubstitutions(tree, currentDepth = 1, hasShadowRoot = fals
 
           if (value.indexOf('__this__.') >= 0) {
             const root = hasShadowRoot ? '.getRootNode().host' : `${'.parentElement'.repeat(currentDepth)}`;
-          
+
             node.attrs[attr].value = value.replace(/__this__/g, `this${root}`);
           }
         }

--- a/test/cases/jsx-shadow-dom/jsx-shadow-dom.spec.js
+++ b/test/cases/jsx-shadow-dom/jsx-shadow-dom.spec.js
@@ -54,7 +54,7 @@ describe('Run WCC For ', function() {
           const wrapper = new JSDOM(heading.innerHTML);
           const button = wrapper.window.document.querySelector('button');
 
-          expect(button.getAttribute('onclick')).to.be.equal('this.parentElement.parentNode.host.sayHello()');
+          expect(button.getAttribute('onclick')).to.be.equal('this.getRootNode().host.sayHello()');
         });
       });
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #109 

> See an example [here](https://github.com/ProjectEvergreen/greenwood-demo-adapter-vercel/pull/24)

## Summary of Changes
1. Leverage [`getRootNode`](https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode) for `this` references inside DSD generated by JSX

----

This should be merged **_after_** #129 since that PR adds a missing test case and does a fair amount of refactoring