### PR TITLE
bug/issue 144 check CE registry before assuming a custom element definition exists

### DIFF
--- a/src/dom-shim.js
+++ b/src/dom-shim.js
@@ -129,15 +129,14 @@ class CustomElementsRegistry {
   }
 
   define(tagName, BaseClass) {
+    // TODO this should probably fail as per the spec...
+    // e.g. if(this.customElementsRegistry.set(tagName))
+    // https://github.com/ProjectEvergreen/wcc/discussions/145
     this.customElementsRegistry.set(tagName, BaseClass);
   }
 
   get(tagName) {
-    if (this.customElementsRegistry.get(tagName)) {
-      return this.customElementsRegistry.get(tagName);
-    } else {
-      // uh oh...
-    }
+    return this.customElementsRegistry.get(tagName);
   }
 }
 

--- a/src/dom-shim.js
+++ b/src/dom-shim.js
@@ -123,15 +123,19 @@ class HTMLTemplateElement extends HTMLElement {
 // https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry
 class CustomElementsRegistry {
   constructor() {
-    this.customElementsRegistry = {};
+    this.customElementsRegistry = new Map();
   }
 
   define(tagName, BaseClass) {
-    this.customElementsRegistry[tagName] = BaseClass;
+    this.customElementsRegistry.set(tagName, BaseClass);
   }
 
   get(tagName) {
-    return this.customElementsRegistry[tagName];
+    if(this.customElementsRegistry.get(tagName)) {
+      return this.customElementsRegistry.get(tagName)
+    } else {
+      // uh oh...
+    }
   }
 }
 

--- a/src/dom-shim.js
+++ b/src/dom-shim.js
@@ -130,7 +130,7 @@ class CustomElementsRegistry {
 
   define(tagName, BaseClass) {
     // TODO this should probably fail as per the spec...
-    // e.g. if(this.customElementsRegistry.set(tagName))
+    // e.g. if(this.customElementsRegistry.get(tagName))
     // https://github.com/ProjectEvergreen/wcc/discussions/145
     this.customElementsRegistry.set(tagName, BaseClass);
   }

--- a/src/dom-shim.js
+++ b/src/dom-shim.js
@@ -123,6 +123,8 @@ class HTMLTemplateElement extends HTMLElement {
 // https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry
 class CustomElementsRegistry {
   constructor() {
+    // TODO this should probably be a set or otherwise follow the spec?
+    // https://github.com/ProjectEvergreen/wcc/discussions/145
     this.customElementsRegistry = new Map();
   }
 

--- a/src/dom-shim.js
+++ b/src/dom-shim.js
@@ -133,8 +133,8 @@ class CustomElementsRegistry {
   }
 
   get(tagName) {
-    if(this.customElementsRegistry.get(tagName)) {
-      return this.customElementsRegistry.get(tagName)
+    if (this.customElementsRegistry.get(tagName)) {
+      return this.customElementsRegistry.get(tagName);
     } else {
       // uh oh...
     }

--- a/src/wcc.js
+++ b/src/wcc.js
@@ -134,9 +134,7 @@ async function initializeCustomElement(elementURL, tagName, attrs = [], definiti
 
   // https://github.com/ProjectEvergreen/wcc/pull/67/files#r902061804
   const { pathname } = elementURL;
-  const element = tagName
-    ? customElements.get(tagName)
-    : (await import(pathname)).default;
+  const element = customElements.get(tagName) ?? (await import(pathname)).default;
   const dataLoader = (await import(pathname)).getData;
   const data = props
     ? props


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #144

https://github.com/ProjectEvergreen/wcc/assets/895923/0af35395-9292-4bfe-a5c4-fe8c664be181

## Summary of Changes
1. Only use `customElementsRegistry` for checking if a custom element definition exists
1. Refactor `customElementsRegistry` to be a set
1. All tests still passing in Greenwood

----

See https://github.com/ProjectEvergreen/wcc/discussions/145 for more on this topic