### PR TITLE
bug/issue 147 re-use existing DOM shim globals if they exist

### DIFF
--- a/src/dom-shim.js
+++ b/src/dom-shim.js
@@ -137,7 +137,8 @@ class CustomElementsRegistry {
 
 // mock top level aliases (globalThis === window)
 // https://developer.mozilla.org/en-US/docs/Web/API/Window
-globalThis.addEventListener = noop;
-globalThis.document = new Document();
-globalThis.customElements = new CustomElementsRegistry();
-globalThis.HTMLElement = HTMLElement;
+// make this "idempotent" for now until a better idea comes along - https://github.com/ProjectEvergreen/wcc/discussions/145
+globalThis.addEventListener = globalThis.addEventListener ?? noop;
+globalThis.document = globalThis.document ?? new Document();
+globalThis.customElements = globalThis.customElements ?? new CustomElementsRegistry();
+globalThis.HTMLElement = globalThis.HTMLElement ?? HTMLElement;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #147 

https://github.com/ProjectEvergreen/wcc/assets/895923/f8e194ae-1831-488c-a821-b8d491c9c2db

## Summary of Changes
1. Make DOM globals "idempotent" to support multiple reloads in the same process