### PR TITLE
bug/issue 158 preserve query params when loading modules

### DIFF
--- a/src/wcc.js
+++ b/src/wcc.js
@@ -133,9 +133,9 @@ async function initializeCustomElement(elementURL, tagName, attrs = [], definiti
   }
 
   // https://github.com/ProjectEvergreen/wcc/pull/67/files#r902061804
-  const { pathname } = elementURL;
-  const element = customElements.get(tagName) ?? (await import(pathname)).default;
-  const dataLoader = (await import(pathname)).getData;
+  const { href } = elementURL;
+  const element = customElements.get(tagName) ?? (await import(href)).default;
+  const dataLoader = (await import(href)).getData;
   const data = props
     ? props
     : dataLoader

--- a/src/wcc.js
+++ b/src/wcc.js
@@ -133,6 +133,7 @@ async function initializeCustomElement(elementURL, tagName, attrs = [], definiti
   }
 
   // https://github.com/ProjectEvergreen/wcc/pull/67/files#r902061804
+  // https://github.com/ProjectEvergreen/wcc/pull/159
   const { href } = elementURL;
   const element = customElements.get(tagName) ?? (await import(href)).default;
   const dataLoader = (await import(href)).getData;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #158 

## Summary of Changes
1. Use `href` instead of `pathname` to better honor original URL passed to WCC

----

> _Would probably try and figure out a way to test this, but since this will all get refactored soon anyway ( #134 ) not going to worry about it too much right now._