### PR TITLE
chore/fix broken sandbox image links

### DIFF
--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -72,12 +72,12 @@
 
     <sb-card
       title="iPhone 9"
-      thumbnail="https://i.dummyjson.com/data/products/1/thumbnail.jpg"
+      thumbnail="https://d2e6ccujb3mkqf.cloudfront.net/f2c7f593-2e6b-4e39-9d9e-9d92c95d84a3-1_0f59d2ff-bd21-417f-9002-0aa1f1e8236e.jpg"
     ></sb-card>
 
     <pre>
       &lt;sb-card
-        title="iPhone 9" thumbnail="https://i.dummyjson.com/data/products/1/thumbnail.jpg"
+        title="iPhone 9" thumbnail="https://d2e6ccujb3mkqf.cloudfront.net/f2c7f593-2e6b-4e39-9d9e-9d92c95d84a3-1_0f59d2ff-bd21-417f-9002-0aa1f1e8236e.jpg"
       &gt;&lt;/sb-card&gt;
     </pre>
 
@@ -97,12 +97,12 @@
 
     <sb-card-jsx
       title="iPhone X"
-      thumbnail="https://i.dummyjson.com/data/products/2/thumbnail.jpg"
+      thumbnail="https://d2e6ccujb3mkqf.cloudfront.net/7e8317d3-cc5d-42a8-8350-ba6a02560477-1_d64a25e3-e1f3-4172-b7c9-0c96e82c4d3f.jpg"
     ></sb-card-jsx>
 
     <pre>
       &lt;sb-card-jsx
-        title="iPhone X" thumbnail="https://i.dummyjson.com/data/products/2/thumbnail.jpg"
+        title="iPhone X" thumbnail="https://d2e6ccujb3mkqf.cloudfront.net/7e8317d3-cc5d-42a8-8350-ba6a02560477-1_d64a25e3-e1f3-4172-b7c9-0c96e82c4d3f.jpg"
       &gt;&lt;/sb-card-jsx&gt;
     </pre>
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
The placeholder images have broken / 404'd
![Screenshot 2024-06-17 at 9 41 14 PM](https://github.com/ProjectEvergreen/wcc/assets/895923/1f6fa99b-5921-4a5f-8406-18c24b2c2fac)

## Summary of Changes
1. Fixed it

![Screenshot 2024-06-17 at 9 42 15 PM](https://github.com/ProjectEvergreen/wcc/assets/895923/22487ae1-4257-420b-9a7a-e094afcde89b)