### PR TITLE
bug/issue 174 swap escodegen with astring for modern JS syntax support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "wc-compiler",
-  "version": "0.13.0",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-compiler",
-      "version": "0.13.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@projectevergreen/acorn-jsx-esm": "~0.1.0",
-        "@projectevergreen/escodegen-esm": "~0.1.0",
         "acorn": "^8.7.0",
         "acorn-import-attributes": "^1.9.5",
         "acorn-walk": "^8.2.0",
+        "astring": "^1.9.0",
         "parse5": "^6.0.1",
         "sucrase": "^3.35.0"
       },
@@ -960,26 +960,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@projectevergreen/escodegen-esm": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@projectevergreen/escodegen-esm/-/escodegen-esm-0.1.0.tgz",
-      "integrity": "sha512-LM9FFffsXPHiOFt78K3bgF8kO8Fx+qluAPy9jP3H4lvCFE+2nbwQM4cWdOpVik++rHf4pkDA7FxDPWWATyBABg==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "25.0.7",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
@@ -1491,6 +1471,14 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "bin": {
+        "astring": "bin/astring"
       }
     },
     "node_modules/async": {
@@ -2962,6 +2950,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -3001,6 +2990,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -3010,6 +3000,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8279,6 +8270,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -10338,17 +10330,6 @@
       "resolved": "https://registry.npmjs.org/@projectevergreen/acorn-jsx-esm/-/acorn-jsx-esm-0.1.0.tgz",
       "integrity": "sha512-ZBSkr0e2M4ylq74dTGHSkWI2dF3Mz8zwBLyzIXZMftecKDADcsCTj7bWltVgtdl8Rh4+bmY1jNWUw7AlSV/r7A=="
     },
-    "@projectevergreen/escodegen-esm": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@projectevergreen/escodegen-esm/-/escodegen-esm-0.1.0.tgz",
-      "integrity": "sha512-LM9FFffsXPHiOFt78K3bgF8kO8Fx+qluAPy9jP3H4lvCFE+2nbwQM4cWdOpVik++rHf4pkDA7FxDPWWATyBABg==",
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "source-map": "~0.6.1"
-      }
-    },
     "@rollup/plugin-commonjs": {
       "version": "25.0.7",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
@@ -10716,6 +10697,11 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
+    },
+    "astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="
     },
     "async": {
       "version": "2.6.4",
@@ -11734,7 +11720,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
@@ -11757,12 +11744,14 @@
     "estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -15372,6 +15361,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "optional": true
     },
     "space-separated-tokens": {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
   },
   "dependencies": {
     "@projectevergreen/acorn-jsx-esm": "~0.1.0",
-    "@projectevergreen/escodegen-esm": "~0.1.0",
     "acorn": "^8.7.0",
     "acorn-import-attributes": "^1.9.5",
     "acorn-walk": "^8.2.0",
+    "astring": "^1.9.0",
     "parse5": "^6.0.1",
     "sucrase": "^3.35.0"
   },

--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -2,8 +2,10 @@
 // https://nodejs.org/api/esm.html#esm_loaders
 import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
-import { generate } from '@projectevergreen/escodegen-esm';
+import { generate } from 'astring';
 import fs from 'fs';
+// ideally we can eventually adopt an ESM compatible version of this plugin
+// https://github.com/acornjs/acorn-jsx/issues/112
 import jsx from '@projectevergreen/acorn-jsx-esm';
 import { parse, parseFragment, serialize } from 'parse5';
 // Need an acorn plugin for now - https://github.com/ProjectEvergreen/greenwood/issues/1218

--- a/src/wcc.js
+++ b/src/wcc.js
@@ -4,7 +4,7 @@ import './dom-shim.js';
 
 import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
-import { generate } from '@projectevergreen/escodegen-esm';
+import { generate } from 'astring';
 import { getParser, parseJsx } from './jsx-loader.js';
 import { parse, parseFragment, serialize } from 'parse5';
 // Need an acorn plugin for now - https://github.com/ProjectEvergreen/greenwood/issues/1218

--- a/test/cases/attributes/src/components/counter.js
+++ b/test/cases/attributes/src/components/counter.js
@@ -1,8 +1,11 @@
 class Counter extends HTMLElement {
+  #count;
+
   constructor(props = {}) {
     super();
 
     this.props = props;
+    this.#count = 0;
 
     if (this.shadowRoot) {
       this.hydrate();
@@ -18,20 +21,20 @@ class Counter extends HTMLElement {
   }
 
   setCount() {
-    this.count = this.hasAttribute('count')
+    this.#count = this.hasAttribute('count')
       ? parseInt(this.getAttribute('count'), 10)
       : this.props.count
         ? this.props.count
-        : 0;
+        : this.#count;
   }
 
   inc() {
-    this.count += 1;
+    this.#count += 1;
     this.update();
   }
 
   dec() {
-    this.count -= 1;
+    this.#count -= 1;
     this.update();
   }
 
@@ -46,7 +49,7 @@ class Counter extends HTMLElement {
   }
 
   update() {
-    this.shadowRoot.querySelector('span#count').textContent = this.count;
+    this.shadowRoot.querySelector('span#count').textContent = this.#count;
   }
 
   render() {
@@ -54,7 +57,7 @@ class Counter extends HTMLElement {
       <template shadowrootmode="open">
         <div>
           <button id="inc">Increment</button>
-          <span>Current Count: <span id="count">${this.count}</span></span>
+          <span>Current Count: <span id="count">${this.#count}</span></span>
           <button id="dec">Decrement</button>
         </div>
       </template>

--- a/test/cases/jsx/src/counter.jsx
+++ b/test/cases/jsx/src/counter.jsx
@@ -1,6 +1,8 @@
 import './badge.jsx';
 
 export default class Counter extends HTMLElement {
+  #count;
+
   constructor() {
     super();
     this.count = 0;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #174 

## Summary of Changes
1. Swap out **escodegen** with [**astring**](https://github.com/davidbonnet/astring) since escodegen seems to be unmaintained (and now we can archive our custom fork since astring is ESM compatible)

## TODO
1. [x] validate in https://github.com/ProjectEvergreen/greenwood/pull/1321