### PR TITLE
bug/preserve light dom html entities in text nodes

### DIFF
--- a/src/wcc.js
+++ b/src/wcc.js
@@ -188,7 +188,8 @@ function renderLightDomChildren(childNodes, iHTML = '') {
         ? ''
         : `</${nodeName}>`;
     } else if (nodeName === '#text') {
-      innerHTML += value;
+      // TODO what about legitimate < content?
+      innerHTML += value.replace(/</g, '&lt;');
     }
   });
 

--- a/test/cases/light-dom-html-entities/light-dom-html-entities.spec.js
+++ b/test/cases/light-dom-html-entities/light-dom-html-entities.spec.js
@@ -1,6 +1,6 @@
 /*
  * Use Case
- * Run wcc against HTML with Light DOM HTML entities.
+ * Run wcc against HTML with Light DOM HTML entities in text nodes.
  * 
  * User Result
  * Should return the expected HTML with all the HTML entities preserved.

--- a/test/cases/light-dom-html-entities/light-dom-html-entities.spec.js
+++ b/test/cases/light-dom-html-entities/light-dom-html-entities.spec.js
@@ -1,0 +1,41 @@
+/*
+ * Use Case
+ * Run wcc against HTML with Light DOM HTML entities.
+ * 
+ * User Result
+ * Should return the expected HTML with all the HTML entities preserved.
+ *
+ * User Workspace
+ * src/
+ *   components/
+ *     ctc-block.js
+ */
+import chai from 'chai';
+import { renderFromHTML } from '../../../src/wcc.js';
+
+const expect = chai.expect;
+
+describe('Run WCC ', function() {
+  const LABEL = 'Using renderFromHTML with Light DOM HTML entities preserved';
+
+  describe(LABEL, function() {
+    let rawHtml;
+
+    before(async function() {
+      const { html } = await renderFromHTML(`
+        <x-ctc>
+          &#x3C;h1>Hello from the server rendered users page! 👋&#x3C;/h1>
+        </x-ctc>
+        `, 
+      [
+        new URL('./src/components/ctc-block.js', import.meta.url)
+      ]);
+
+      rawHtml = html;
+    });
+
+    it('should preserve HTML entities', function() {
+      expect(rawHtml).to.contain('&lt;h1&gt;Hello from the server rendered users page! 👋&lt;/h1&gt;');
+    });
+  });
+});

--- a/test/cases/light-dom-html-entities/src/components/ctc-block.js
+++ b/test/cases/light-dom-html-entities/src/components/ctc-block.js
@@ -1,0 +1,5 @@
+export default class CopyToClipboardBlock extends HTMLElement {
+
+}
+
+customElements.define('x-ctc', CopyToClipboardBlock);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
https://github.com/ProjectEvergreen/greenwood/issues/1375

## Summary of Changes
1. Naive implementation for preserving HTML entities in text nodes
1. Add test case

## TODO
1. [ ] Should we handle `>` too?  Others?
1. [ ] Would this not "mangle" legitimate uses of `<` too?

---

Regarding the second point above, it seems through the serialization process parse5 will even encode legitimate `<` even when not using our `replace` function?  🤔 
```sh
{
  value: '\n' +
    '          <h1>Hello from the server rendered users < page! 👋</h1>\n' +
    '        '
}
{
  html: '\n' +
    '        <x-ctc>\n' +
    '          <h1>Hello from the server rendered users &lt; page! 👋</h1>\n' +
    '        </x-ctc>\n' +
    '        '
}
```