### PR TITLE
feature/issue 193 WCC types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     - name: Lint
       run: |
         npm run lint
+    - name: Check Types
+      run: |
+        npm run lint:types
     - name: Test
       run: |
         npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "@eslint/js": "^9.11.1",
         "@ls-lint/ls-lint": "^1.10.0",
         "@mapbox/rehype-prism": "^0.8.0",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^22.13.4",
         "c8": "^7.11.2",
         "chai": "^4.3.6",
         "concurrently": "^7.1.0",
@@ -44,10 +46,11 @@
         "remark-toc": "^8.0.1",
         "rimraf": "^3.0.2",
         "simple.css": "^0.1.3",
+        "typescript": "^5.7.3",
         "unified": "^10.1.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1094,12 +1097,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true
+    },
     "node_modules/@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
@@ -8426,12 +8444,31 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true
     },
     "node_modules/unified": {
       "version": "10.1.2",
@@ -10021,11 +10058,26 @@
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true
+    },
     "@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "22.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.20.0"
+      }
     },
     "@types/parse5": {
       "version": "6.0.3",
@@ -15069,10 +15121,22 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true
+    },
     "undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true
     },
     "unified": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,12 @@
     "type": "git",
     "url": "https://github.com/ProjectEvergreen/wcc.git"
   },
-  "main": "src/wcc.js",
   "type": "module",
+  "main": "src/wcc.js",
+  "exports": {
+    ".": "./src/wcc.js",
+    "./types": "./src/index.d.ts"
+  },
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "keywords": [
     "Web Components",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "lint": "eslint",
+    "lint:types": "tsc --project tsconfig.json",
     "docs:dev": "concurrently \"nodemon --watch src --watch docs -e js,md,css,html,jsx ./build.js\" \"http-server ./dist --open\"",
     "docs:build": "node ./build.js",
     "docs:serve": "npm run clean && npm run docs:build && http-server ./dist --open",
@@ -53,6 +54,8 @@
     "@eslint/js": "^9.11.1",
     "@ls-lint/ls-lint": "^1.10.0",
     "@mapbox/rehype-prism": "^0.8.0",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^22.13.4",
     "c8": "^7.11.2",
     "chai": "^4.3.6",
     "concurrently": "^7.1.0",
@@ -74,6 +77,7 @@
     "remark-toc": "^8.0.1",
     "rimraf": "^3.0.2",
     "simple.css": "^0.1.3",
+    "typescript": "^5.7.3",
     "unified": "^10.1.2"
   }
 }

--- a/src/dom-shim.js
+++ b/src/dom-shim.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { parse, parseFragment, serialize } from 'parse5';
 
 export function getParse(html) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,18 @@
+export type Metadata = object[{
+  [key: string]: {
+    instanceName: string;
+    moduleURL: URL;
+    isEntry: boolean
+  }
+}]
+
+// async function renderToString(elementURL, wrappingEntryTag = true, props = {}) {
+export type renderToString = (elementURL: URL, wrappingEntryTag?: boolean, props?: any) => Promise<{
+  html: string;
+  metadata: Metadata
+}>
+
+export type renderFromHTML = (html: string, elementURLs: URL[]) => Promise<{
+  html: string;
+  metadata: Metadata
+}>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,6 @@ export type Metadata = object[{
   }
 }]
 
-// async function renderToString(elementURL, wrappingEntryTag = true, props = {}) {
 export type renderToString = (elementURL: URL, wrappingEntryTag?: boolean, props?: any) => Promise<{
   html: string;
   metadata: Metadata

--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -5,6 +5,8 @@ import { generate } from 'astring';
 import fs from 'fs';
 // ideally we can eventually adopt an ESM compatible version of this plugin
 // https://github.com/acornjs/acorn-jsx/issues/112
+// @ts-ignore
+// but it does have a default export???
 import jsx from '@projectevergreen/acorn-jsx-esm';
 import { parse, parseFragment, serialize } from 'parse5';
 import { transform } from 'sucrase';
@@ -250,11 +252,13 @@ export function parseJsx(moduleURL) {
 
   walk.simple(tree, {
     ClassDeclaration(node) {
+      // @ts-ignore
       if (node.superClass.name === 'HTMLElement') {
         const hasShadowRoot = moduleContents.slice(node.body.start, node.body.end).indexOf('this.attachShadow(') > 0;
 
         for (const n1 of node.body.body) {
           if (n1.type === 'MethodDefinition') {
+            // @ts-ignore
             const nodeName = n1.key.name;
             if (nodeName === 'render') {
               for (const n2 in n1.value.body.body) {
@@ -265,6 +269,7 @@ export function parseJsx(moduleURL) {
                     ...observedAttributes,
                     ...findThisReferences('render', n)
                   ];
+                  // @ts-ignore
                 } else if (n.type === 'ReturnStatement' && n.argument.type === 'JSXElement') {
                   const html = parseJsxElement(n.argument, moduleContents);
                   const elementTree = getParse(html)(html);
@@ -296,6 +301,7 @@ export function parseJsx(moduleURL) {
                     sourceType: 'module'
                   });
 
+                  // @ts-ignore
                   n1.value.body.body[n2] = transformed;
                 }
               }
@@ -308,7 +314,9 @@ export function parseJsx(moduleURL) {
       const { declaration } = node;
 
       if (declaration && declaration.type === 'VariableDeclaration' && declaration.kind === 'const' && declaration.declarations.length === 1) {
+        // @ts-ignore
         if (declaration.declarations[0].id.name === 'inferredObservability') {
+          // @ts-ignore
           inferredObservability = Boolean(node.declaration.declarations[0].init.raw);
         }
       }
@@ -316,6 +324,7 @@ export function parseJsx(moduleURL) {
   }, {
     // https://github.com/acornjs/acorn/issues/829#issuecomment-1172586171
     ...walk.base,
+    // @ts-ignore
     JSXElement: () => {}
   });
 
@@ -324,7 +333,9 @@ export function parseJsx(moduleURL) {
     let insertPoint;
     for (const line of tree.body) {
       // test for class MyComponent vs export default class MyComponent
+      // @ts-ignore
       if (line.type === 'ClassDeclaration' || (line.declaration && line.declaration.type) === 'ClassDeclaration') {
+        // @ts-ignore
         insertPoint = line.declaration.body.start + 1;
       }
     }

--- a/src/wcc.js
+++ b/src/wcc.js
@@ -169,13 +169,7 @@ async function initializeCustomElement(elementURL, tagName, node = {}, definitio
   }
 }
 
-/**
- * @param {URL} elementURL - The entry point custom element definition
- * @param {boolean} wrappingEntryTag - Whether to wrap (or not wrap) your entry point's HTML in a custom element tag 
- * @param {any} props - Constructor props
- *
- * @returns {Promise<{ html: string, metadata: any[] }>}- Fully rendered HTML contents and custom elements metadata
- */
+/** @type {import('./index.d.ts').renderToString} */
 async function renderToString(elementURL, wrappingEntryTag = true, props = {}) {
   const definitions = [];
   const elementTagName = wrappingEntryTag && await getTagName(elementURL);
@@ -216,12 +210,7 @@ async function renderToString(elementURL, wrappingEntryTag = true, props = {}) {
   };
 }
 
-/**
- * @param {string} html - The HTML contents to render from
- * @param {URL[]} elements - Custom element definitions to pass to the renderer
- *
- * @returns {Promise<{ html: string, metadata: any[] }>} Fully rendered HTML contents and custom elements metadata
- */
+/** @type {import('./index.d.ts').renderFromHTML} */
 async function renderFromHTML(html, elements = []) {
   const definitions = [];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "checkJs": true,
+    "allowJs": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": [
+      "mocha",
+      "node"
+    ]
+  },
+  "include": [
+    "./src/",
+    "./test/**/*.spec.js"
+  ]
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #193 

## Summary of Changes
1. Add `type` definitions for `renderFromHTML` and `renderToString`
1. Add basic type checking for CI (applied some low-handing fruit recommendations)
1. Update _package.json_ to export types and adopt `exports` field (will consider this a breaking change)

## TODO
1. [x] refine metadata type (and types field?) - https://merry-caramel-524e61.netlify.app/docs/#metadata
    - default values
    - required vs optional
1. [x] Do we need to expose any types via _package.json_?
    - metadata as a type?
1. [x] (nice to have / good first issue) had to add a number of `@ts-ignores` since a lot of the AST related work threw TS errors - https://github.com/ProjectEvergreen/wcc/issues/197