### PR TITLE
feature/issue 193 top level `types` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "type": "module",
   "main": "src/wcc.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/wcc.js",
     "./types": "./src/index.d.ts",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #193 

## Summary of Changes

1. Forgot to add top-level `types` field (primarily for NPM badge)