### PR TITLE
bug: #203 correct export types and functions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,14 +6,17 @@ export type Metadata = {
   }
 }
 
-export type renderToString = (elementURL: URL, wrappingEntryTag?: boolean, props?: any) => Promise<{
+type renderToString = (elementURL: URL, wrappingEntryTag?: boolean, props?: any) => Promise<{
   html: string;
   metadata: Metadata
 }>
 
-export type renderFromHTML = (html: string, elementURLs: URL[]) => Promise<{
+type renderFromHTML = (html: string, elementURLs: URL[]) => Promise<{
   html: string;
   metadata: Metadata
 }>
 
-declare module "wc-compiler" { }
+declare module "wc-compiler" {
+  export const renderToString: renderToString;
+  export const renderFromHTML: renderFromHTML;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,12 +6,12 @@ export type Metadata = {
   }
 }
 
-type renderToString = (elementURL: URL, wrappingEntryTag?: boolean, props?: any) => Promise<{
+export type renderToString = (elementURL: URL, wrappingEntryTag?: boolean, props?: any) => Promise<{
   html: string;
   metadata: Metadata
 }>
 
-type renderFromHTML = (html: string, elementURLs: URL[]) => Promise<{
+export type renderFromHTML = (html: string, elementURLs: URL[]) => Promise<{
   html: string;
   metadata: Metadata
 }>

--- a/src/wcc.js
+++ b/src/wcc.js
@@ -169,9 +169,7 @@ async function initializeCustomElement(elementURL, tagName, node = {}, definitio
   }
 }
 
-/** @type {import('./index.d.ts').renderToString} */
 async function renderToString(elementURL, wrappingEntryTag = true, props = {}) {
-  /** @type {import('./index.d.ts').Metadata} */
   const definitions = {};
   const elementTagName = wrappingEntryTag && await getTagName(elementURL);
   const isEntry = !!elementTagName;
@@ -211,9 +209,7 @@ async function renderToString(elementURL, wrappingEntryTag = true, props = {}) {
   };
 }
 
-/** @type {import('./index.d.ts').renderFromHTML} */
 async function renderFromHTML(html, elements = []) {
-  /** @type {import('./index.d.ts').Metadata} */
   const definitions = {};
 
   for (const url of elements) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #203 

## Summary of Changes
1. Correctly export API functions and types

----

Removed the types from the source since it was causing conflicts
<img width="1225" height="660" alt="Screenshot 2025-09-20 at 6 32 59 PM" src="https://github.com/user-attachments/assets/4990d2a5-7a96-42ee-98c6-cee6d5177e8f" />

But it all still works anyway, like hovering over the export in a test case
<img width="1257" height="439" alt="Screenshot 2025-09-20 at 6 33 19 PM" src="https://github.com/user-attachments/assets/095d50aa-0d15-48fb-91ac-d04caaa47239" />