### PR TITLE
fix: reorder exports so types is first and update repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "description": "Experimental native Web Components compiler.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ProjectEvergreen/wcc.git"
+    "url": "git+https://github.com/ProjectEvergreen/wcc.git"
   },
   "type": "module",
   "main": "src/wcc.js",
   "types": "./src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./src/index.d.ts",
       "import": "./src/wcc.js",
-      "types": "./src/index.d.ts"
+      "require": "./src/wcc.js"
     },
     "./register": "./src/register.js",
     "./src/jsx-loader.js": "./src/jsx-loader.js",


### PR DESCRIPTION
… URL

<!-- ## Submitting a Pull Request We love contributions and appreciate any help you can offer! -->
Related Issue

Resolves #216 — Fix publint feedback for package.json

Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists 1. [x] Updated repository URL to full git format (`git+https://github.com/ProjectEvergreen/wcc.git`) 1. [x] Reordered `exports["."]` so `"types"` is first 1. [x] Ran `npx publint` and confirmed no errors -->