### PR TITLE
lint: switch to jsonc

### DIFF
--- a/docs/pages/docs.md
+++ b/docs/pages/docs.md
@@ -387,9 +387,7 @@ There are of couple things you will need to do to use WCC with JSX:
 
 TSX (.tsx) file are also supported and your HTML will also be **type-safe**. You'll need to configure JSX in your _tsconfig.json_ by adding these two lines to your `compilerOptions` settings:
 
-<!-- prettier-ignore-start -->
-
-```json5
+```jsonc
 {
   "compilerOptions": {
     // required options
@@ -398,12 +396,10 @@ TSX (.tsx) file are also supported and your HTML will also be **type-safe**. You
 
     // additional recommended options
     "allowImportingTsExtensions": true,
-    "erasableSyntaxOnly": true
-  }
+    "erasableSyntaxOnly": true,
+  },
 }
 ```
-
-<!-- prettier-ignore-end -->
 
 If you create your own custom elements and use them in your TSX components, you'll need to define your own `interface` for them:
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

Follow-up to #209, switching to jsonc allows us to remove the prettier exemption and still get proper markdown highlighting.

<img width="750" height="369" alt="image" src="https://github.com/user-attachments/assets/993a3ab0-448d-4c59-8d21-4187648401eb" />

## Related Issue

#180 

## Summary of Changes

<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
1. [x] `json5` -> `jsonc`
2. [x] Remove prettier comments
3. [x] Ran prettier format
