### PR TITLE
fix: #193 add missing source property on the `Metadata` type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,7 @@ export type Metadata = {
     instanceName: string;
     moduleURL: URL;
     isEntry: boolean;
+    source: string;
   };
 };
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #193 

Found the `source` property was missing on the `Metadata` type

<img width="983" height="550" alt="Screenshot 2025-12-30 at 6 23 24 PM" src="https://github.com/user-attachments/assets/15a81d68-b574-44e2-b18d-809b44cdcad0" />

## Summary of Changes

1. Add a type for the `source` property on `Metadata` type