### PR TITLE
enhancement: #236 narrow popovertarget JSX attrs to button/input elements only

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -7,17 +7,23 @@ type ElementAttributes<E extends HTMLElement> = {
   [A in keyof E]?: E[A] extends (...args: any) => any ? any : IsCSSStyleDeclaration<E[A]>;
 } & {
   class?: string;
+};
+
+type PopoverTargetAction = 'show' | 'hide' | 'toggle';
+type PopoverTargetAttributes = {
   // have to manage this manually, can't seem to get this from TypeScript itself (not sure if just skill issue? :D)
   // https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1790
   // it should be there per https://github.com/mdn/browser-compat-data/pull/21875
   // https://github.com/ProjectEvergreen/wcc/issues/236
+  // per the spec, this should only apply to <button> and <input> elements.
   popovertarget?: string;
-  popovertargetaction?: 'show' | 'hide' | 'toggle';
+  popovertargetaction?: PopoverTargetAction;
 };
 
 // map each HTML tag to its attributes
 type IntrinsicElementsFromDom = {
-  [E in keyof HTMLElementTagNameMap]: ElementAttributes<HTMLElementTagNameMap[E]>;
+  [E in keyof HTMLElementTagNameMap]: ElementAttributes<HTMLElementTagNameMap[E]> &
+    (E extends 'button' | 'input' ? PopoverTargetAttributes : {});
 };
 
 declare namespace JSX {

--- a/test/cases/tsx/src/header.tsx
+++ b/test/cases/tsx/src/header.tsx
@@ -2,9 +2,14 @@
 export default class Header extends HTMLElement {
   render() {
     return (
-      <button popovertarget="mobile-menu" popovertargetaction="hide">
-        Close
-      </button>
+      <header>
+        <button popovertarget="mobile-menu" popovertargetaction="hide">
+          Close
+        </button>
+
+        {/* @ts-expect-error popovertarget should only be valid on <button> and <input> */}
+        <span popovertarget="mobile-menu">Close</span>
+      </header>
     );
   }
 }


### PR DESCRIPTION
Fixes #236.

TypeScript's DOM lib doesn't currently expose popovertarget/popovertargetaction, so WCC adds them manually for JSX typing. Per spec, these attributes should only be valid on <button> and <input>.

Changes:
- Move popover attributes into a dedicated `PopoverTargetAttributes` type
- Apply it conditionally only to the button and input intrinsic elements
- Add a `@ts-expect-error` TSX fixture to ensure other tags (e.g. span) error

Verification:
- npm run lint:types
- npm test
