### PR TITLE
docs: #202 feature and capability boxes padding tweaks

### DIFF
--- a/docs/components/capability-box/capability-box.module.css
+++ b/docs/components/capability-box/capability-box.module.css
@@ -18,6 +18,8 @@
   border-radius: var(--radius-2);
   padding: var(--size-2);
   font-size: var(--size-3);
+  margin: 0 0 var(--size-1) 0;
+  display: inline-block;
 }
 
 @media (min-width: 1024px) {

--- a/docs/components/feature-box/feature-box.module.css
+++ b/docs/components/feature-box/feature-box.module.css
@@ -3,7 +3,7 @@
   border-radius: var(--radius-3);
   color: var(--color-primary);
   min-height: 300px;
-  padding: var(--size-2) var(--size-4);
+  padding: var(--size-4);
   margin: var(--size-1);
 
   & p {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #202 / #222 

## Summary of Changes

1. The feature and capability boxes on mobile were looking a little squished on mobile
    - feature boxes needed a little extra padding between the heading and subheading
    - capabilities had too little padding on the bottom
    
 
<img width="603" height="1311" alt="Screenshot 2026-02-05 at 16 03 18" src="https://github.com/user-attachments/assets/11da67b0-1821-465d-8118-4d93eb3d5c23" />
<img width="603" height="1311" alt="Screenshot 2026-02-05 at 16 03 01" src="https://github.com/user-attachments/assets/3213e0ee-195d-4a77-861b-42a92868f4d4" />