### PR TITLE
docs: #202 make sure mobile menu dialog covers the entire page

### DIFF
--- a/docs/components/header/header.module.css
+++ b/docs/components/header/header.module.css
@@ -61,6 +61,8 @@
 
 .mobileMenuContainer {
   flex: 1;
+  width: 100%;
+  height: 100vh;
 }
 
 .mobileMenuList {
@@ -103,12 +105,11 @@
 }
 
 .mobileMenuBackdrop {
-  height: 99vh;
-  width: 96vw;
   margin: 0;
   background-color: #f5f5f58e;
   padding: var(--size-5) var(--size-6);
   text-align: right;
+  height: 99vh;
 }
 
 .mobileMenuCloseButton {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #202 / #222 

## Summary of Changes

1. Mobile menu dropdown `<dialog>` did not cover the entire screen


<img width="556" height="765" alt="Screenshot 2026-02-05 at 4 07 46 PM" src="https://github.com/user-attachments/assets/db35bd0a-8c4d-402d-95d7-9be45edcff87" />