### PR TITLE
docs: #202 add accent ring border color around cta button

### DIFF
--- a/docs/components/banner-cta/banner-cta.module.css
+++ b/docs/components/banner-cta/banner-cta.module.css
@@ -19,7 +19,7 @@
 .snippet {
   color: var(--color-primary);
   border-radius: var(--radius-4);
-  border: var(--radius-1) solid #c1d3cd;
+  border: var(--radius-1) solid var(--color-accent);
   box-shadow: var(--shadow-2);
   margin: var(--size-px-2) 0;
   text-align: center;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#202 / #222 

## Summary of Changes

1. Added an accent color around the CTA button to make it pop a little bit more, especially on mobile where there is no copy to clipboard icon

<img width="538" height="401" alt="Screenshot 2026-02-06 at 10 54 19 AM" src="https://github.com/user-attachments/assets/a314f8a5-24bb-4d02-9045-fdf75ea5ddd5" />

<img width="644" height="499" alt="Screenshot 2026-02-06 at 10 49 35 AM" src="https://github.com/user-attachments/assets/c3f8a971-1b7c-4f5f-9ce5-a20a06fb173f" />