### PR TITLE
docs: #202 fix safari issues with css module scripts

### DIFF
--- a/greenwood.config.ts
+++ b/greenwood.config.ts
@@ -8,6 +8,9 @@ const config: Config = {
   activeContent: true,
   workspace: new URL('./docs/', import.meta.url),
   prerender: true,
+  polyfills: {
+    importAttributes: ['css'],
+  },
   plugins: [
     greenwoodPluginImportRaw(),
     greenwoodPluginCssModules(),


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #202 / #222 

## Summary of Changes

1. Forgot to enable CSS Module Scripts polyfill that was causing a number of issues across desktop / mobile


**No CTA on desktop**

<img width="1895" height="975" alt="Screenshot 2026-02-06 at 7 02 40 PM" src="https://github.com/user-attachments/assets/34448ed8-0d60-4fe2-8b11-d333d852d1d2" />

**No code box headings**

> Observed in #241 
<img width="1886" height="986" alt="Screenshot 2026-02-06 at 7 02 54 PM" src="https://github.com/user-attachments/assets/bac4e655-971d-4a4d-bd65-3de08178e6b6" />