### PR TITLE
docs: #202 fix discord link in social tray

### DIFF
--- a/docs/components/social-tray/social-tray.tsx
+++ b/docs/components/social-tray/social-tray.tsx
@@ -20,7 +20,7 @@ export default class SocialTray extends HTMLElement {
         </li>
 
         <li class={styles.socialIcon}>
-          <a href="/discord/" title="Discord" target="_blank">
+          <a href="https://www.greenwoodjs.dev/discord/" title="Discord" target="_blank">
             {discordIcon}
             <span class="no-show-screen-reader"> (opens in a new window)</span>
           </a>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

realized this while working on #246 

<img width="1390" height="994" alt="Screenshot 2026-02-07 at 9 35 59 AM" src="https://github.com/user-attachments/assets/add811dc-7134-4b8f-8014-20d6c94e3b8a" />

## Summary of Changes

1. Fix the discord link