### PR TITLE
enhancement(jsx): replace innerHtml with clone from template

### DIFF
--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -348,24 +348,14 @@ export function parseJsx(moduleURL) {
                     applyDomDepthSubstitutions(elementTree, undefined, hasShadowRoot);
 
                     const serializedHtml = serialize(elementTree);
-                    // we have to Shadow DOM use cases here
-                    // 1. No shadowRoot, so we attachShadow and append the template
-                    // 2. If there is root from the attachShadow signal, so we just need to inject innerHTML, say in an htmx
-                    // could / should we do something else instead of .innerHTML
-                    // https://github.com/ProjectEvergreen/wcc/issues/138
-                    const renderHandler = hasShadowRoot
-                      ? `
-                        const template = document.createElement('template');
-                        template.innerHTML = \`${serializedHtml}\`;
 
-                        if(!${elementRoot}) {
-                          this.attachShadow({ mode: 'open' });
-                          this.shadowRoot.appendChild(template.content.cloneNode(true));
-                        } else {
-                          this.shadowRoot.innerHTML = template.innerHTML;
-                        }
-                      `
-                      : `${elementRoot}.innerHTML = \`${serializedHtml}\`;`;
+                    const renderHandler = `
+                      const template = document.createElement('template');
+                      template.innerHTML = \`${serializedHtml}\`;
+
+                      ${elementRoot}.textContent = '';
+                      ${elementRoot}.appendChild(template.content.cloneNode(true));
+                    `;
                     const transformed = acorn.parse(renderHandler, {
                       ecmaVersion: 'latest',
                       sourceType: 'module',


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

Push the template contents into web component's root instead of setting innerHtml directly. Simplifies the code.

## Related Issue

<!-- Include a link to the issue (e.g. Resolves #12) -->
Resolves #138 

## Summary of Changes

<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
- Use template clone instead of innerHtml assignment in all cases.
- Replace the conditional shadowDom/lightDom handling with a single approach, based on the rationale that `hasShadowRoot` being true means `this.attachShadow({ mode: 'open' })` must also have been called. 
- Use textContent = '' to clear existing contents ([faster than innerHtml = ''](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innerhtml))
