### PR TITLE
bug: remove patch-package postinstall script breaking npm installs

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Installing project dependencies
         run: |
           npm ci
+      # Greenwood specific patches
+      - name: Run patch-package
+        run: |
+          npx patch-package
       - name: Setup Playwright
         run: |
           npx playwright install --with-deps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ To develop for the project, you'll want to follow these steps:
 1. Clone the repository
 1. Have [NodeJS LTS](https://nodejs.org) installed and / or use `nvm` (see below)
 1. Run `npm ci`
+1. Run `npx patch-package`
 1. Run `npx playwright install`
 
 ### NVM

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "test:tdd:jsx": "npm run test:jsx -- --watch",
     "test:docs": "vitest run --coverage",
     "test:docs:tdd": "vitest",
-    "prepare": "husky",
-    "postinstall": "patch-package"
+    "prepare": "husky"
   },
   "dependencies": {
     "@projectevergreen/acorn-jsx-esm": "~0.1.0",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#233 

## Summary of Changes

1. Remove patch-package `postinstall` script that was breaking npm installs in https://github.com/ProjectEvergreen/greenwood/pull/1667
1. Document manual running of `patch-package` in _CONTRIBUTING.md_

-----

The failure is due to WCC having a `postinstall` script to run **patch-package** but as it is only a dev dep, it won't be found and will fail.  (and honestly, we really shouldn't be shipping with a `postinstall` script)

<img width="1490" height="587" alt="Screenshot 2026-04-15 at 10 49 05 PM" src="https://github.com/user-attachments/assets/e98167c3-27de-490a-86b5-1eab3778368f" />

```sh
warning Workspaces can only be enabled in private projects.
[4/4] Building fresh packages...
error /home/runner/work/greenwood/greenwood/node_modules/wc-compiler: Command failed.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Exit code: 127
Command: patch-package
Arguments: 
Directory: /home/runner/work/greenwood/greenwood/node_modules/wc-compiler
Output:
/bin/sh: 1: patch-package: not found
Error: Process completed with exit code 127.
```