### PR TITLE
docs: remove gap between code block headings and body on smaller breakpoints

### DIFF
--- a/docs/components/ctc-block/ctc-block.css
+++ b/docs/components/ctc-block/ctc-block.css
@@ -21,8 +21,8 @@
     display: inline-block;
     background-color: var(--color-prism-bg);
     color: var(--color-white);
-    padding: 10px;
-    font-size: var(--size-3);
+    padding: var(--size-2);
+    font-size: var(--size-2);
     border-radius: var(--radius-2) var(--radius-2) 0 0;
     font-family: 'Geist-Mono', monospace;
     font-style: italic;
@@ -71,6 +71,14 @@
 .snippet-container:has(.heading) {
   & .copy-icon {
     top: 50px;
+  }
+}
+
+@media (min-width: 500px) {
+  .snippet-container {
+    & .heading {
+      font-size: var(--size-3);
+    }
   }
 }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

was seeing this on my iPhone

https://wcc.dev/docs/
<img width="911" height="907" alt="Screenshot 2026-04-16 at 8 10 39 PM" src="https://github.com/user-attachments/assets/a7601a6d-7b11-495b-8596-5ba8cbc4c2b9" />

## Summary of Changes

1. Fix gap between code block heading and body on smaller breakpoints

----

Probably a better way to do this with CSS since not sure why this issue happens, but it looks bad so at least wanted to get a quick fix in for now.