### PR TITLE
docs: #268 fix github stars badge counter display

### DIFF
--- a/docs/components/header/header.tsx
+++ b/docs/components/header/header.tsx
@@ -64,7 +64,7 @@ export default class Header extends HTMLElement {
         <div class={styles.badgeContainer}>
           <a class={styles.badge} href="https://github.com/ProjectEvergreen/wcc" target="_blank">
             <img
-              src="https://img.shields.io/github/stars/ProjectEvergreen/wcc.svg?style=social&logo=github&label=github"
+              src="https://img.shields.io/github/stars/ProjectEvergreen/wcc?style=social&label=GitHub"
               alt="WCC GitHub badge"
               width={135}
               class="github-badge"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #268 

## Summary of Changes

1. Used the [shields.io playground](https://shields.io/badges/git-hub-repo-stars) to get it working again

<img width="521" height="101" alt="Screenshot 2026-05-07 at 9 01 52 AM" src="https://github.com/user-attachments/assets/ff451465-4384-46ce-a33a-f693224bd5d8" />