### PR TITLE
docs: correctly apply height to GitHub badge image

### DIFF
--- a/docs/components/header/header.tsx
+++ b/docs/components/header/header.tsx
@@ -66,6 +66,7 @@ export default class Header extends HTMLElement {
             <img
               src="https://img.shields.io/github/stars/ProjectEvergreen/wcc?style=social&label=GitHub"
               alt="WCC GitHub badge"
+              height={28}
               width={135}
               class="github-badge"
             />


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/playground.wcc.dev/pull/28/changes#diff-68cc9b2ae68025896b813f0a23dbca6edb5a7284df1899fb0b001f5642006b6aR85

## Summary of Changes

1. correctly apply height to GitHub badge image
