### PR TITLE
chore: exclude CSS from code coverage reports

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -107,7 +107,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['./docs/components/**'],
-      exclude: ['./docs/components/sandbox/**'],
+      exclude: ['./docs/components/sandbox/**', './docs/components/**/*.module.css'],
       thresholds: {
         lines: 65,
         functions: 75,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

No need for CSS to be included in code coverage reports
<img width="1128" height="736" alt="Screenshot 2026-05-13 at 10 01 32" src="https://github.com/user-attachments/assets/f2b2fa25-e96b-4216-a1da-fa0e2e48d1c8" />

## Summary of Changes

1. Exclude CSS from code coverage reports

<img width="1099" height="750" alt="Screenshot 2026-05-13 at 10 10 47" src="https://github.com/user-attachments/assets/b46b2882-d07d-462c-9a61-c7fa541aecfb" />
