### PR TITLE
docs: #259 fix capability box height consistency

### DIFF
--- a/docs/components/capability-box/capability-box.module.css
+++ b/docs/components/capability-box/capability-box.module.css
@@ -1,6 +1,8 @@
 .container {
   background-color: var(--color-primary);
   border-radius: var(--radius-3);
+  box-sizing: border-box;
+  height: 100%;
   padding: var(--size-4);
   text-align: left;
   min-height: 150px;
@@ -30,6 +32,6 @@
 
 @media (min-width: 1200px) {
   .container {
-    min-height: 160px;
+    min-height: 200px;
   }
 }

--- a/docs/styles/home.css
+++ b/docs/styles/home.css
@@ -124,6 +124,11 @@ wcc-capability-box {
   }
 
   .capabilities-container {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-rows: 1fr;
+    gap: var(--size-3);
+    align-items: stretch;
     width: 80%;
     margin: 0 auto;
     padding: 0;
@@ -136,15 +141,15 @@ wcc-capability-box {
   }
 
   wcc-capability-box {
-    display: inline-block;
-    width: 44%;
-    margin: var(--size-3);
-    vertical-align: top;
+    display: block;
+    width: 100%;
+    margin: 0;
   }
 }
 
 @media (min-width: 1200px) {
   .capabilities-container {
+    gap: var(--size-2);
     padding: var(--size-2);
   }
 
@@ -160,9 +165,8 @@ wcc-capability-box {
   }
 
   wcc-capability-box {
-    display: inline-block;
-    width: 47%;
-    margin: var(--size-2);
-    vertical-align: top;
+    display: block;
+    width: 100%;
+    margin: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Switch the capability section to a two-column CSS grid at desktop breakpoints.
- Stretch grid rows and the inner capability cards so the boxes stay the same height across the desktop layout.
- Keep the 1200px breakpoint from shrinking the card minimum height below the 1024px layout.

Fixes #259

## Verification
- npm.cmd run lint:css
- npm.cmd run format:check -- docs/styles/home.css docs/components/capability-box/capability-box.module.css
- npm.cmd run test:docs
- Playwright layout check against the local docs site: capability card heights were uniform at 1024px, 1200px, and 1440px.