### PR TITLE
bug: #258 jsx shadow root detection using wrong source input contents

### DIFF
--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -432,7 +432,7 @@ export function parseJsx(moduleURL) {
           // TODO: (good first issue) find a more AST (visitor) based way to check for this
           // https://github.com/ProjectEvergreen/wcc/issues/258
           hasShadowRoot =
-            moduleContents.slice(node.body.start, node.body.end).indexOf('this.attachShadow(') > 0;
+            result.code.slice(node.body.start, node.body.end).indexOf('this.attachShadow(') > 0;
 
           for (const n1 of node.body.body) {
             if (n1.type === 'MethodDefinition') {
@@ -773,6 +773,7 @@ export function parseJsx(moduleURL) {
           ) {
             // TODO: do we even need this filter?
             const trackingAttrs = observedAttributes.filter((attr) => typeof attr === 'string');
+            // TODO: should we append cleanup functions if user has their own disconnected callback?
             const disconnectedCallbackContents = hasDisconnectedCallback
               ? ''
               : `

--- a/src/jsx-loader.js
+++ b/src/jsx-loader.js
@@ -773,7 +773,7 @@ export function parseJsx(moduleURL) {
           ) {
             // TODO: do we even need this filter?
             const trackingAttrs = observedAttributes.filter((attr) => typeof attr === 'string');
-            // TODO: should we append cleanup functions if user has their own disconnected callback?
+            // create a disconnectedCallback function if not present to append effect cleanup functions
             const disconnectedCallbackContents = hasDisconnectedCallback
               ? ''
               : `
@@ -817,13 +817,13 @@ export function parseJsx(moduleURL) {
           }
         },
         MethodDefinition(node) {
+          // append DOM references and effect functions for signals
           if (node.key.name === 'connectedCallback') {
             const root = hasShadowRoot ? 'this.shadowRoot' : 'this';
             const effectElements = reactiveElements
               .map((el, idx) => `this.$el${idx} = ${root}.querySelector('${el.selector}');`)
               .join('\n');
             const effectContents = generateEffectsForReactiveElements(reactiveElements);
-
             const effectElementsTree = acorn.parse(effectElements, acornParseOptions);
             const effectContentsTree = acorn.parse(effectContents, acornParseOptions);
 
@@ -834,6 +834,7 @@ export function parseJsx(moduleURL) {
             ];
           }
 
+          // append cleanup functions.if component already has a disconnectedCallback
           if (node.key.name === 'disconnectedCallback' && hasDisconnectedCallback) {
             const effectCleanupContents =
               generateEffectsCleanupForReactiveElements(reactiveElements);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to (but doesn't _resolve_) #258 

----

Observed in https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/112 that we were not getting a Shadow Root out of a component that was using `attachShadow`, which was then causing it to not render


<img width="1868" height="917" alt="Screenshot 2026-06-11 at 9 09 20 AM" src="https://github.com/user-attachments/assets/f1364d04-cc1e-4a3b-9d6d-393eba50540e" />
<img width="1842" height="840" alt="Screenshot 2026-06-11 at 9 09 39 AM" src="https://github.com/user-attachments/assets/86f511ce-c819-4a4a-afca-0338b1f091e2" />

## Summary of Changes

1. Have shadow root check against source input being walked over (not the initial module contents)