### PR TITLE
fix: #277 fix `<svg>` types

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -49,6 +49,17 @@ type IntrinsicElementsFromSVG = {
   [E in keyof SVGElementTagNameMap]: SVGElementAttributes<SVGElementTagNameMap[E]>;
 };
 
+type IntrinsicElementAttributes<E extends string> = (E extends keyof HTMLElementTagNameMap
+  ? ElementAttributes<HTMLElementTagNameMap[E]> &
+      (E extends 'button' | 'input' ? PopoverAttributes : {}) &
+      (E extends 'button' ? { tabindex?: number | string } : {})
+  : {}) &
+  (E extends keyof SVGElementTagNameMap ? SVGElementAttributes<SVGElementTagNameMap[E]> : {});
+
+type IntrinsicElementsMap = {
+  [E in keyof HTMLElementTagNameMap | keyof SVGElementTagNameMap]: IntrinsicElementAttributes<E>;
+};
+
 declare namespace JSX {
-  interface IntrinsicElements extends IntrinsicElementsFromDom, IntrinsicElementsFromSVG {}
+  interface IntrinsicElements extends IntrinsicElementsMap {}
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #277 

Was seeing [this error](https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/112#issuecomment-4822948240) in this project
```sh
node_modules/wc-compiler/src/jsx.d.ts:53:13 - error TS2320: Interface 'IntrinsicElements' cannot simultaneously extend types 'IntrinsicElementsFromDom' and 'IntrinsicElementsFromSVG'.
  Named property '"a"' of types 'IntrinsicElementsFromDom' and 'IntrinsicElementsFromSVG' are not identical.

53   interface IntrinsicElements extends IntrinsicElementsFromDom, IntrinsicElementsFromSVG {}
               ~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/wc-compiler/src/jsx.d.ts:53
```

## Summary of Changes

1. Fixup `<svg>` types

## TODO
1. [x] test in other JSX projects - https://github.com/thescientist13/greenwood-jsx/pull/14
